### PR TITLE
fixed scrolling with mouse (1)

### DIFF
--- a/arc-core/src/io/anuke/arc/scene/ui/Dialog.java
+++ b/arc-core/src/io/anuke/arc/scene/ui/Dialog.java
@@ -72,6 +72,15 @@ public class Dialog extends Window{
                 }
             }
         };
+        
+        shown(() -> Core.app.post(() ->
+        forEach(child -> {
+
+            if(child instanceof ScrollPane){
+                Core.scene.setScrollFocus(child);
+            }
+        })));
+        
     }
 
     public static void setHideAction(Supplier<Action> prov){

--- a/arc-core/src/io/anuke/arc/scene/ui/KeybindDialog.java
+++ b/arc-core/src/io/anuke/arc/scene/ui/KeybindDialog.java
@@ -181,7 +181,8 @@ public class KeybindDialog extends Dialog{
         cont.row();
 
         cont.add(pane).growX().colspan(sections.length);
-
+        Core.app.post(() -> Core.scene.setScrollFocus(pane));
+        
     }
 
     private void rebind(Section section, KeyBind bind, KeyCode newKey){


### PR DESCRIPTION
Hey,

I noticed a little bug, which made it impossible to scroll through some dialogs with the mouse on a desktop machine.

Affected Dialogs:
- ControlsDialog
- AboutDialog
- SettingsDialog (Graphics)
- etc.

Note: This is part one of the fix. Part two is on the Mindustry repository.