### PR TITLE
Sprite packing related changes.

### DIFF
--- a/arc-core/src/io/anuke/arc/graphics/g2d/PixmapPacker.java
+++ b/arc-core/src/io/anuke/arc/graphics/g2d/PixmapPacker.java
@@ -377,6 +377,7 @@ public class PixmapPacker implements Disposable{
                     region.originalHeight = rect.originalHeight;
 
                     atlas.getRegions().add(region);
+                    atlas.getRegionMap().put(name, region);
                 }
                 page.addedRects.clear();
                 atlas.getTextures().add(page.texture);
@@ -846,8 +847,8 @@ public class PixmapPacker implements Disposable{
     }
 
     public static class PixmapPackerRectangle extends Rectangle{
-        int[] splits;
-        int[] pads;
+        public int[] splits;
+        public int[] pads;
         int offsetX, offsetY;
         int originalWidth, originalHeight;
 

--- a/arc-core/src/io/anuke/arc/graphics/g2d/PixmapPacker.java
+++ b/arc-core/src/io/anuke/arc/graphics/g2d/PixmapPacker.java
@@ -583,9 +583,6 @@ public class PixmapPacker implements Disposable{
             rgba[3] = (int)(c.a * 255);
             if(rgba[3] == breakA) return next;
 
-            if(!startPoint && (rgba[0] != 0 || rgba[1] != 0 || rgba[2] != 0 || rgba[3] != 255))
-                System.out.println(x + "  " + y + " " + Arrays.toString(rgba) + " ");
-
             next++;
         }
 

--- a/arc-core/src/io/anuke/arc/graphics/g2d/TextureAtlas.java
+++ b/arc-core/src/io/anuke/arc/graphics/g2d/TextureAtlas.java
@@ -170,12 +170,24 @@ public class TextureAtlas implements Disposable{
         return regions;
     }
 
+    /** Returns the region map in the atlas. */
+    public ObjectMap<String, AtlasRegion> getRegionMap(){
+        return regionmap;
+    }
+
     /** Returns the blank 1x1 texture region, if it exists.*/
     public AtlasRegion white(){
         if(white == null){
             white = find("white");
         }
         return white;
+    }
+
+    /** Finds and sets error region as name. */
+    public boolean setErrorRegion(String name) {
+        if(error != null || !has(name)) return false;
+        error = find(name);
+        return true;
     }
 
     public boolean isFound(TextureRegion region){


### PR DESCRIPTION
Error region can be set on TextureAtlas, PixmapPacker now correctly adds regions to regionmap and splits/pads can be accessed in PixmapPackerRectangle.