### PR TITLE
Fix lowercase spelling of magenta

### DIFF
--- a/arc-core/src/io/anuke/arc/graphics/Colors.java
+++ b/arc-core/src/io/anuke/arc/graphics/Colors.java
@@ -130,7 +130,7 @@ public final class Colors{
         map.put("coral", Color.coral);
         map.put("salmon", Color.salmon);
         map.put("pink", Color.pink);
-        map.put("magneta", Color.magenta);
+        map.put("magenta", Color.magenta);
 
         map.put("purple", Color.purple);
         map.put("violet", Color.violet);


### PR DESCRIPTION
<img width="697" alt="Screen Shot 2019-10-22 at 09 16 38" src="https://user-images.githubusercontent.com/3179271/67264896-ac132980-f4ac-11e9-9bae-b6f202bf5126.png">
