### PR TITLE
fix missing music in MacOS

### DIFF
--- a/backends/backend-sdl/src/main/java/io/anuke/arc/backends/sdl/audio/ALMusic.java
+++ b/backends/backend-sdl/src/main/java/io/anuke/arc/backends/sdl/audio/ALMusic.java
@@ -60,7 +60,6 @@ public abstract class ALMusic implements Music{
                     throw new ArcRuntimeException("Unable to allocate audio buffers. AL Error: " + errorCode);
             }
 
-            alSourcei(sourceID, /*AL_DIRECT_CHANNELS_SOFT*/ 0x1033, AL_TRUE);
             alSourcei(sourceID, AL_LOOPING, AL_FALSE);
             setPan(pan, volume);
 


### PR DESCRIPTION
I'm using MacOS (10.12.6 Sierra) and I had no music in game. After some debugging I found that this line actually fails on my system, and soundtrack stopped later in following code:
```
            if(alGetError() != AL_NO_ERROR){
                stop();
```
I didn't find how you can use `AL_DIRECT_CHANNELS_SOFT` with `alSourcei`, so I've just removed it and this solved issue for me.

If you need this call, I can adjust PR to ignore an error after setting `AL_DIRECT_CHANNELS_SOFT` like this:
```
            alSourcei(sourceID, /*AL_DIRECT_CHANNELS_SOFT*/ 0x1033, AL_TRUE);
            alGetError(); // ignore
            ...
```