### PR TITLE
Add individual reset keybind button

### DIFF
--- a/arc-core/src/io/anuke/arc/KeyBinds.java
+++ b/arc-core/src/io/anuke/arc/KeyBinds.java
@@ -129,12 +129,7 @@ public class KeyBinds{
         settings.remove(rname + "-min");
         settings.remove(rname + "-max");
 
-        KeybindValue value = bind.defaultValue(section.device.type());
-        if(value instanceof Axis){
-            section.binds.getOr(section.device.type(), OrderedMap::new).put(bind, (Axis) value);
-        }else if(value instanceof KeyCode){
-            section.binds.getOr(section.device.type(), OrderedMap::new).put(bind, new Axis((KeyCode) value));
-        }
+        section.binds.getOr(section.device.type(), OrderedMap::new).remove(bind);
     }
 
     private void save(Axis axis, String name){

--- a/arc-core/src/io/anuke/arc/KeyBinds.java
+++ b/arc-core/src/io/anuke/arc/KeyBinds.java
@@ -130,9 +130,9 @@ public class KeyBinds{
         settings.remove(rname + "-max");
 
         KeybindValue value = bind.defaultValue(section.device.type());
-        if (value instanceof Axis) {
+        if(value instanceof Axis){
             section.binds.getOr(section.device.type(), OrderedMap::new).put(bind, (Axis) value);
-        } else if (value instanceof KeyCode) {
+        }else if(value instanceof KeyCode){
             section.binds.getOr(section.device.type(), OrderedMap::new).put(bind, new Axis((KeyCode) value));
         }
     }

--- a/arc-core/src/io/anuke/arc/KeyBinds.java
+++ b/arc-core/src/io/anuke/arc/KeyBinds.java
@@ -118,6 +118,25 @@ public class KeyBinds{
         }
     }
 
+    /**
+     * Resets a keybind to its default value.
+     * Call Core.settings.save() to flush the change afterwards.
+     */
+    public void resetToDefault(Section section, KeyBind bind){
+        String rname = "keybind-" + section.name + "-" + section.device.name() + "-" + bind.name();
+        settings.remove(rname + "-single");
+        settings.remove(rname + "-key");
+        settings.remove(rname + "-min");
+        settings.remove(rname + "-max");
+
+        KeybindValue value = bind.defaultValue(section.device.type());
+        if (value instanceof Axis) {
+            section.binds.getOr(section.device.type(), OrderedMap::new).put(bind, (Axis) value);
+        } else if (value instanceof KeyCode) {
+            section.binds.getOr(section.device.type(), OrderedMap::new).put(bind, new Axis((KeyCode) value));
+        }
+    }
+
     private void save(Axis axis, String name){
         settings.put(name + "-single", axis.key != null);
 

--- a/arc-core/src/io/anuke/arc/scene/ui/KeybindDialog.java
+++ b/arc-core/src/io/anuke/arc/scene/ui/KeybindDialog.java
@@ -155,7 +155,7 @@ public class KeybindDialog extends Dialog{
                         openDialog(section, keybind);
                     }).width(110f);
                 }
-                table.addButton(bundle.get("settings.reset_key", "Reset"), () -> {
+                table.addButton(bundle.get("settings.resetKey", "Reset"), () -> {
                     keybinds.resetToDefault(section, keybind);
                     setup();
                     settings.save();

--- a/arc-core/src/io/anuke/arc/scene/ui/KeybindDialog.java
+++ b/arc-core/src/io/anuke/arc/scene/ui/KeybindDialog.java
@@ -143,10 +143,6 @@ public class KeybindDialog extends Dialog{
                         rebindMin = true;
                         openDialog(section, keybind);
                     }).width(110f);
-                    table.addButton(bundle.get("settings.reset_key", "Reset"), () -> {
-                        resetKey(section, keybind);
-                    }).width(100f);
-                    table.row();
                 }else{
                     table.add(bundle.get("keybind." + keybind.name() + ".name", Strings.capitalize(keybind.name())),
                     style.keyNameColor).left().padRight(40).padLeft(8);
@@ -158,11 +154,13 @@ public class KeybindDialog extends Dialog{
                         rebindMin = false;
                         openDialog(section, keybind);
                     }).width(110f);
-                    table.addButton(bundle.get("settings.reset_key", "Reset"), () -> {
-                        resetKey(section, keybind);
-                    }).width(100f);
-                    table.row();
                 }
+                table.addButton(bundle.get("settings.reset_key", "Reset"), () -> {
+                    keybinds.resetToDefault(section, keybind);
+                    setup();
+                    settings.save();
+                }).width(100f);
+                table.row();
             }
 
             table.visible(() -> this.section.equals(section));
@@ -180,19 +178,6 @@ public class KeybindDialog extends Dialog{
 
         cont.add(pane).growX().colspan(sections.length);
 
-    }
-
-    private void resetKey(Section section, KeyBind bind){
-        String rname = "keybind-" + section.name + "-" + section.device.name() + "-" + bind.name();
-        settings.remove(rname + "-single");
-        settings.remove(rname + "-key");
-        settings.remove(rname + "-min");
-        settings.remove(rname + "-max");
-
-        settings.save();
-        rebindKey = null;
-        rebindAxis = false;
-        setup();
     }
 
     private void rebind(Section section, KeyBind bind, KeyCode newKey){

--- a/arc-core/src/io/anuke/arc/scene/ui/KeybindDialog.java
+++ b/arc-core/src/io/anuke/arc/scene/ui/KeybindDialog.java
@@ -143,17 +143,24 @@ public class KeybindDialog extends Dialog{
                         rebindMin = true;
                         openDialog(section, keybind);
                     }).width(110f);
+                    table.addButton(bundle.get("settings.reset_key", "Reset"), () -> {
+                        resetKey(section, keybind);
+                    }).width(100f);
                     table.row();
                 }else{
                     table.add(bundle.get("keybind." + keybind.name() + ".name", Strings.capitalize(keybind.name())),
                     style.keyNameColor).left().padRight(40).padLeft(8);
                     table.add(keybinds.get(section, keybind).key.toString(),
                     style.keyColor).left().minWidth(90).padRight(20);
+
                     table.addButton(bundle.get("settings.rebind", "Rebind"), () -> {
                         rebindAxis = false;
                         rebindMin = false;
                         openDialog(section, keybind);
                     }).width(110f);
+                    table.addButton(bundle.get("settings.reset_key", "Reset"), () -> {
+                        resetKey(section, keybind);
+                    }).width(100f);
                     table.row();
                 }
             }
@@ -173,6 +180,19 @@ public class KeybindDialog extends Dialog{
 
         cont.add(pane).growX().colspan(sections.length);
 
+    }
+
+    private void resetKey(Section section, KeyBind bind){
+        String rname = "keybind-" + section.name + "-" + section.device.name() + "-" + bind.name();
+        settings.remove(rname + "-single");
+        settings.remove(rname + "-key");
+        settings.remove(rname + "-min");
+        settings.remove(rname + "-max");
+
+        settings.save();
+        rebindKey = null;
+        rebindAxis = false;
+        setup();
     }
 
     private void rebind(Section section, KeyBind bind, KeyCode newKey){


### PR DESCRIPTION
Adds Reset button to the right of the Rebind button.
When clicked, binds the action to its default key/axis.
(Not sure about the table.row(); and button bit outside of if/else, it was redundant as both axis and normal keys used reset.)
First pull request, please tell me if there's anything you want changed :)