### PR TITLE
properly exit on android

### DIFF
--- a/backends/backend-android/src/arc/backend/android/AndroidApplication.java
+++ b/backends/backend-android/src/arc/backend/android/AndroidApplication.java
@@ -378,7 +378,7 @@ public class AndroidApplication extends Activity implements Application{
 
     @Override
     public void exit(){
-        handler.post(AndroidApplication.this::finish);
+        handler.post(Build.VERSION.SDK_INT < 21 ? AndroidApplication.this::finish : AndroidApplication.this::finishAndRemoveTask);
     }
 
     @Override


### PR DESCRIPTION
use finishAndRemoveTask added in lollipop, fixes the messy stuff with not swiping away the finished app before restarting it