### PR TITLE
Add CommandHandler#getPrefix

### DIFF
--- a/arc-core/src/arc/util/CommandHandler.java
+++ b/arc-core/src/arc/util/CommandHandler.java
@@ -19,6 +19,10 @@ public class CommandHandler{
     public void setPrefix(String prefix){
         this.prefix = prefix;
     }
+    
+    public String getPrefix(){
+        return prefix;   
+    }
 
     /** Handles a message with no additional parameters.*/
     public CommandResponse handleMessage(String message){


### PR DESCRIPTION
Would be very useful in Kotlin applications, where you can directly access and change private properties using `setPrefix` and `getPrefix` methods. For example:

![image](https://user-images.githubusercontent.com/55251897/103671096-824c0280-4f8b-11eb-8451-6b37bf54b3a4.png)
