### PR TITLE
use proper newline char

### DIFF
--- a/arc-core/src/arc/util/io/PropertiesUtils.java
+++ b/arc-core/src/arc/util/io/PropertiesUtils.java
@@ -33,7 +33,7 @@ import java.util.Date;
  */
 public final class PropertiesUtils{
     private static final int NONE = 0, SLASH = 1, UNICODE = 2, CONTINUE = 3, KEY_DONE = 4, IGNORE = 5;
-    private static final String LINE_SEPARATOR = "\n";
+    private static final String LINE_SEPARATOR = System.lineSeparator();
 
     private PropertiesUtils(){
     }


### PR DESCRIPTION
Use the correct newline char to avoid "editing" the file by changing the newlines every single time the game is built as seen here: ![](https://xenon.is-ne.at/ngvdqa.png)
This is the same method that is used for the BufferedWriter class in java.io: ![](https://yagpdb.is-ne.at/lJQdpm.png)