### PR TITLE
Fix "Pause In Background" setting in Windows

### DIFF
--- a/backends/backend-sdl/src/main/java/arc/backend/sdl/SdlApplication.java
+++ b/backends/backend-sdl/src/main/java/arc/backend/sdl/SdlApplication.java
@@ -125,9 +125,9 @@ public class SdlApplication implements Application{
                     if(type == SDL_WINDOWEVENT_SIZE_CHANGED){
                         graphics.updateSize(inputs[2], inputs[3]);
                         listen(l -> l.resize(inputs[2], inputs[3]));
-                    }else if(type == SDL_WINDOWEVENT_SHOWN){
+                    }else if(type == SDL_WINDOWEVENT_FOCUS_GAINED){
                         listen(ApplicationListener::resume);
-                    }else if(type == SDL_WINDOWEVENT_HIDDEN){
+                    }else if(type == SDL_WINDOWEVENT_FOCUS_LOST){
                         listen(ApplicationListener::pause);
                     }
                 }else if(inputs[0] == SDL_EVENT_MOUSE_MOTION ||


### PR DESCRIPTION
I've solved the issue with "pause in background" on Windows. It can be fixed by replacing `SDL_WINDOWEVENT_SHOWN/HIDDEN` with `..._RESTORED/MINIMIZED`. This would replicate the current Linux behavior to Windows correctly.

However, I recommend using `..._FOCUS_GAINED/FOCUS_LOST` instead, which would pause the game whenever you've Alt+Tabbed to another app. This would allow the setting to function regardless if the game is fullscreen, borderless fullscreen, or windowed, whereas pause on minimize requires that the game be kept in windowed mode.

Every other game I've seen that has an "...in background" setting, such as "mute audio in background", works with focus, not minimize. That's what "in background" means, so if you actually mean minimize, then the setting should be renamed to "pause while minimized".

I have tested both `..._RESTORED/MINIMIZED` and `..._FOCUS_GAINED/FOCUS_LOST`, they both work on Windows 10. **Please test on Linux.**

The reason I think `..._SHOWN/HIDDEN` doesn't work on Windows but does on Linux is because on Windows, hiding a window may mean it's hidden even from the taskbar, such as when an app is hidden to the system tray. Since Linux does not natively have a system tray, it may not distinguish between minimized and hidden windows.

[SDL window events](https://wiki.libsdl.org/SDL_WindowEventID)