### PR TITLE
Clarify that absolute filetype is not only for absolute file paths

### DIFF
--- a/arc-core/src/arc/Files.java
+++ b/arc-core/src/arc/Files.java
@@ -98,8 +98,8 @@ public interface Files{
         external,
 
         /**
-         * Path that is a fully qualified, absolute filesystem path. To ensure portability across platforms use absolute files only
-         * when absolutely (heh) necessary.
+         * Path that is interpreted as a verbatim filesystem path. To ensure portability across platforms use absolute files only
+         * when absolutely (heh) necessary. Relative paths will use the current working directory.
          */
         absolute,
 


### PR DESCRIPTION
Follow up on https://github.com/Anuken/Mindustry/pull/4851