### PR TITLE
Allow passing object to log.debug

### DIFF
--- a/arc-core/src/arc/util/Log.java
+++ b/arc-core/src/arc/util/Log.java
@@ -19,6 +19,10 @@ public class Log{
     public static void debug(String text, Object... args){
         log(LogLevel.debug, text, args);
     }
+    
+    public static void debug(Object object){
+        debug(String.valueOf(object), empty);
+    }
 
     public static void infoList(Object... args){
         if(level.ordinal() > LogLevel.info.ordinal()) return;


### PR DESCRIPTION
Its annoying trying to use debug logging to log things that arent already strings