### PR TITLE
Invoking methods with Reflect

### DIFF
--- a/arc-core/src/arc/util/Reflect.java
+++ b/arc-core/src/arc/util/Reflect.java
@@ -75,6 +75,32 @@ public class Reflect{
         set(type, null, name, value);
     }
 
+    public static <T> T invoke(Class<?> type, Object object, String name, Object[] args, Class<?>... parameterTypes){
+        try{
+            Method method = type.getDeclaredMethod(name, parameterTypes);
+            method.setAccessible(true);
+            return (T)method.invoke(object, args);
+        }catch(Exception e){
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T> T invoke(Class<?> type, String name, Object[] args, Class<?>... parameterTypes){
+        return invoke(type, null, name, args, parameterTypes);
+    }
+
+    public static <T> T invoke(Class<?> type, String name){
+        return invoke(type, name, null);
+    }
+
+    public static <T> T invoke(Object object, String name, Object[] args, Class<?>... parameterTypes){
+        return invoke(object.getClass(), object, name, args, parameterTypes);
+    }
+
+    public static <T> T invoke(Object object, String name){
+        return invoke(object, name, null);
+    }
+
     public static <T> T make(String type){
         try{
             Class<T> c = (Class<T>)Class.forName(type);


### PR DESCRIPTION
Works with both static and non-static methods.

Example:
```java
public class ReflectTest{
    private static int staticNumber(int number){
        return number;
    }

    private static int staticNumber(){
        return 42;
    }

    private int number(int number){
        return number;
    }

    private int number(){
        return 42;
    }

    public static void main(String[] args){
        int staticNumber = Reflect.invoke(ReflectTest.class, "staticNumber");
        int staticNumber2 = Reflect.invoke(ReflectTest.class, "staticNumber", new Object[]{42}, int.class);

        int number = Reflect.invoke(new ReflectTest(), "number");
        int number2 = Reflect.invoke(new ReflectTest(), "number", new Object[]{42}, int.class);
    }
}
```