### PR TITLE
Set default depth size to 16 in SdlConfig

### DIFF
--- a/backends/backend-sdl/src/arc/backend/sdl/SdlConfig.java
+++ b/backends/backend-sdl/src/arc/backend/sdl/SdlConfig.java
@@ -6,7 +6,7 @@ import arc.graphics.gl.*;
 
 public class SdlConfig{
     public int r = 8, g = 8, b = 8, a = 8;
-    public int depth = 0, stencil = 0;
+    public int depth = 16, stencil = 0;
     public int samples = 0;
     public HdpiMode hdpiMode = HdpiMode.logical;
 


### PR DESCRIPTION
[Android](https://github.com/Anuken/Arc/blob/ca296ad37aeca186fcef3290bb8a6e9143bdd245/backends/backend-android/src/arc/backend/android/AndroidApplicationConfiguration.java#L17) and [iOS](https://github.com/Anuken/Arc/blob/ca296ad37aeca186fcef3290bb8a6e9143bdd245/backends/backend-robovm/src/arc/backend/robovm/IOSApplicationConfiguration.java#L21) has this default value of `16`, so why not SDL too? This would probably be nice for extensions that do not have power to resize the depth buffer size *(such as game mods, yes you know what I'm talking about)*.