### PR TITLE
Enable color codes in windows terminal

### DIFF
--- a/arc-core/src/arc/util/ColorCodes.java
+++ b/arc-core/src/arc/util/ColorCodes.java
@@ -37,8 +37,8 @@ public class ColorCodes{
 
     static{
 
-        //disable color codes on windows/android
-        if(OS.isWindows || OS.isAndroid){
+        //disable color codes on windows/android (ignore windows terminal which supports colors)
+        if((OS.isWindows && !OS.hasEnv("WT_SESSION")) || OS.isAndroid){
             flush = reset = bold = underline = black = red = green = yellow = blue = purple = cyan = lightWhite
             = lightBlack = lightRed = lightGreen = lightYellow = lightBlue = lightMagenta = lightCyan
             = white = backDefault = backRed = backYellow = backBlue = backGreen = italic = "";


### PR DESCRIPTION
Windows terminal supports color codes, might as well enable them.

Windows terminal (now with color, don't mind the cursed steam fps counter):
![](https://extremely.questionable.link/5hfZdcNck.png)

CMD (same as before):
![](https://aethex.is-a.fail/5hfZrjONN.png)

I suppose this also allows people to set the env var manually if they wish to enable color in intellij or whatever as well.

Intellij without env var:
![](https://i-dont.go-outsi.de/5hfZUlbht.png)

Intellij with env var:
![](https://aethex.is-a.fail/5hf_bb2Bu.png)