### PR TITLE
Fill.arc fix

### DIFF
--- a/arc-core/src/arc/graphics/g2d/Fill.java
+++ b/arc-core/src/arc/graphics/g2d/Fill.java
@@ -266,6 +266,7 @@ public class Fill{
 
             polyPoint(x + x1, y + y1);
         }
+        polyPoint(x, y);
         
         polyEnd();
     }


### PR DESCRIPTION
Yea don't know why it needs the center point a second time, but without it it doesn't fully fill the arc

![7QkU2lIQnE](https://user-images.githubusercontent.com/54301439/153135058-930ecb2f-b609-416b-80e4-476378f44f11.png)