### PR TITLE
"fix" horrible quadtree removal slowness

### DIFF
--- a/arc-core/src/arc/math/geom/QuadTree.java
+++ b/arc-core/src/arc/math/geom/QuadTree.java
@@ -22,6 +22,7 @@ public class QuadTree<T extends QuadTreeObject>{
     public Rect bounds;
     public Seq<T> objects = new Seq<>(false);
     public QuadTree<T> botLeft, botRight, topLeft, topRight;
+    private final Seq<QuadTree<T>> stack = new Seq<>();
     public boolean leaf = true;
 
     public QuadTree(Rect bounds){
@@ -114,8 +115,22 @@ public class QuadTree<T extends QuadTreeObject>{
                 objects.remove(obj, true);
             }
 
-            if(getTotalObjectCount() <= maxObjectsPerNode) unsplit();
+            if(hasSpace()) unsplit();
         }
+    }
+    
+    private boolean hasSpace(){
+        int count = 0;
+        stack.clear().add(this);
+        while(!stack.isEmpty()){
+            QuadTree<T> current = stack.pop();
+            count += current.objects.size;
+            if(count > maxObjectsPerNode) return false;
+            if(!current.leaf){
+                stack.add(current.botLeft, current.topRight, current.topLeft, current.botRight);
+            }
+        }
+        return true;
     }
 
     /** Removes all objects. */


### PR DESCRIPTION
This is by no means a good fix. I left the old method intact for compatibility (and just for counting stuff tbf). The newly introduced method is pretty much the old one except that it has the option to return early, the performance impact is very noticeable as I go from 3-4 fps to >30fps when removing ~100 objects from a QuadTree every frame.
As you can see, the old way was pretty bad (unsure as to how much better the new way is but I notice a massive difference so eh):
![Oh god](https://aethex.is-a.fail/5oIsAmw9u.png)