### PR TITLE
Global Pitch

### DIFF
--- a/arc-core/src/arc/audio/Audio.java
+++ b/arc-core/src/arc/audio/Audio.java
@@ -8,6 +8,7 @@ import static arc.audio.Soloud.*;
 
 /** High-level wrapper for the Soloud library. */
 public class Audio implements Disposable{
+    public float globalPitch = 1f;
     /** Falloff when playing audio.*/
     public float falloff = 16000f;
 

--- a/arc-core/src/arc/audio/Sound.java
+++ b/arc-core/src/arc/audio/Sound.java
@@ -27,6 +27,8 @@ import static arc.audio.Soloud.*;
  * </p>
  */
 public class Sound extends AudioSource{
+    public static float globalPitch = 1f;
+
     public AudioBus bus = Core.audio == null ? null : Core.audio.soundBus;
 
     long framePlayed;
@@ -58,7 +60,7 @@ public class Sound extends AudioSource{
     public int play(float volume, float pitch, float pan, boolean loop){
         if(handle == 0 || framePlayed == Core.graphics.getFrameId() || bus == null || !Core.audio.initialized) return -1;
         framePlayed = Core.graphics.getFrameId();
-        return sourcePlayBus(handle, bus.handle, volume, pitch, pan, loop);
+        return sourcePlayBus(handle, bus.handle, volume, pitch * globalPitch, pan, loop);
     }
 
     /** Sets the bus that will be used for the next play of this SFX. */

--- a/arc-core/src/arc/audio/Sound.java
+++ b/arc-core/src/arc/audio/Sound.java
@@ -27,8 +27,6 @@ import static arc.audio.Soloud.*;
  * </p>
  */
 public class Sound extends AudioSource{
-    public static float globalPitch = 1f;
-
     public AudioBus bus = Core.audio == null ? null : Core.audio.soundBus;
 
     long framePlayed;
@@ -60,7 +58,7 @@ public class Sound extends AudioSource{
     public int play(float volume, float pitch, float pan, boolean loop){
         if(handle == 0 || framePlayed == Core.graphics.getFrameId() || bus == null || !Core.audio.initialized) return -1;
         framePlayed = Core.graphics.getFrameId();
-        return sourcePlayBus(handle, bus.handle, volume, pitch * globalPitch, pan, loop);
+        return sourcePlayBus(handle, bus.handle, volume, pitch * Core.audio.globalPitch, pan, loop);
     }
 
     /** Sets the bus that will be used for the next play of this SFX. */


### PR DESCRIPTION
Soloud doesn't seem to have a way to change the pitch of every audio. Of course this pull doesn't change the pitch of the sound that's already fired. It would be useful for certain effects, or for my reason: playing the game at half speed, record it and play the video in full speed to reduce lag and hopefully retain audio pitch.