### PR TITLE
run method with Cons

### DIFF
--- a/arc-core/src/arc/Events.java
+++ b/arc-core/src/arc/Events.java
@@ -20,6 +20,11 @@ public class Events{
         events.get(type, () -> new Seq<>(Cons.class)).add(e -> listener.run());
     }
 
+    /** Handle an event by enum trigger. */
+    public static <T> void run(Object type, Cons<T> listener){
+        events.get(type, () -> new Seq<>(Cons.class)).add(e -> listener.get(e));
+    }
+    
     /** Only use this method if you have the reference to the exact listener object that was used. */
     public static <T> boolean remove(Class<T> type, Cons<T> listener){
         return events.get(type, Seq::new).remove(listener);


### PR DESCRIPTION
Simply to make it work like `Events.on`

For example:
![image](https://user-images.githubusercontent.com/69006175/159172746-72ca53c8-ff94-467b-b05e-1abb8fce9eb3.png)
In that case, I have to call it outside `run`.


![image](https://user-images.githubusercontent.com/69006175/159172891-c08cc95d-7980-448a-8e59-73d2ed6567f6.png)
_an adapter, to give a better example with a method_