### PR TITLE
Call run on the DiscordRPC Pipe FutureTask

### DIFF
--- a/extensions/discord/src/arc/discord/DiscordRPC.java
+++ b/extensions/discord/src/arc/discord/DiscordRPC.java
@@ -51,7 +51,9 @@ public final class DiscordRPC{
 
         checkConnected(false);
         try{
-            pipe = new FutureTask<>(() -> Pipe.openPipe(clientId)).get(500, TimeUnit.MILLISECONDS);
+            FutureTask<Pipe> task = new FutureTask<>(() -> Pipe.openPipe(clientId));
+            task.run();
+            pipe = task.get(500, TimeUnit.MILLISECONDS);
         }catch(Exception e){
             throw new NoDiscordClientException();
         }


### PR DESCRIPTION
This fixes the future being waited for infinitely on OpenJDK 17.0.3.u3-1 allowing DiscordRPC to actually connect and function.