### PR TITLE
Fix cachedExecutor having a single thread

### DIFF
--- a/arc-core/src/arc/util/Threads.java
+++ b/arc-core/src/arc/util/Threads.java
@@ -68,12 +68,18 @@ public class Threads{
         return cachedExecutor(min, Integer.MAX_VALUE, true);
     }
 
+    /** @param blocking uses a BlockingQueue rather than a SynchronousQueue. Note that min is ignored when this is true. */
     public static ExecutorService cachedExecutor(int min, int max, boolean blocking){
-        return new ThreadPoolExecutor(min, max,
+        return cachedExecutor(min, max, blocking, null);
+    }
+
+    /** @param blocking uses a BlockingQueue rather than a SynchronousQueue. Note that min is ignored when this is true. */
+    public static ExecutorService cachedExecutor(int min, int max, boolean blocking, String name){
+        return new ThreadPoolExecutor(blocking ? max : min, max,
         30L, TimeUnit.SECONDS,
         blocking ? new LinkedBlockingQueue<>() : new SynchronousQueue<>(),
         r -> {
-            Thread thread = new Thread(r);
+            Thread thread = name != null ? new Thread(r, name) : new Thread(r);
             thread.setDaemon(true);
             thread.setUncaughtExceptionHandler((t, e) -> e.printStackTrace());
             return thread;


### PR DESCRIPTION
https://github.com/openjdk/jdk/blob/9583e3657e43cc1c6f2101a64534564db2a9bd84/src/java.base/share/classes/java/util/concurrent/ThreadPoolExecutor.java#L175-L180

Also may want to enable core thread timeout? Would want to increase the timeout for that though I think.