### PR TITLE
Fixed 

### DIFF
--- a/arc-core/src/arc/scene/ui/TextArea.java
+++ b/arc-core/src/arc/scene/ui/TextArea.java
@@ -15,7 +15,7 @@ import arc.util.pooling.Pools;
 /** A multiple-line text input field, entirely based on {@link TextField} */
 public class TextArea extends TextField{
 
-    /** Array storing lines breaks positions **/
+    /** Array storing starting and ending positions of each line. **/
     protected IntSeq linesBreak;
     /** Current line for the cursor **/
     protected int cursorLine;
@@ -198,10 +198,10 @@ public class TextArea extends TextField{
             if(!((minIndex < lineStart && minIndex < lineEnd && maxIndex < lineStart && maxIndex < lineEnd)
             || (minIndex > lineStart && minIndex > lineEnd && maxIndex > lineStart && maxIndex > lineEnd))){
 
-                int start = Math.max(linesBreak.get(i), minIndex);
-                int end = Math.min(linesBreak.get(i + 1), maxIndex);
+                int start = Math.min(Math.max(linesBreak.get(i), minIndex), glyphPositions.size - 1);
+                int end = Math.min(Math.min(linesBreak.get(i + 1), maxIndex), glyphPositions.size - 1);
 
-                float selectionX = glyphPositions.get(start) - glyphPositions.get(linesBreak.get(i));
+                float selectionX = glyphPositions.get(start) - glyphPositions.get(Math.min(linesBreak.get(i), glyphPositions.size));
                 float selectionWidth = glyphPositions.get(end) - glyphPositions.get(start);
 
                 selection.draw(x + selectionX + fontOffset, y - textHeight - font.getDescent() - offsetY, selectionWidth,

--- a/arc-core/src/arc/scene/ui/TextField.java
+++ b/arc-core/src/arc/scene/ui/TextField.java
@@ -445,7 +445,7 @@ public class TextField extends Element implements Disableable{
             }
         }else{
             fontOffset = 0;
-	}
+        }
         glyphPositions.add(x);
 
         visibleTextStart = Math.min(visibleTextStart, glyphPositions.size);

--- a/arc-core/src/arc/scene/ui/TextField.java
+++ b/arc-core/src/arc/scene/ui/TextField.java
@@ -432,7 +432,7 @@ public class TextField extends Element implements Disableable{
         }else
             displayText = newDisplayText;
 
-        layout.setText(font, displayText);
+        layout.setText(font, displayText.toString().replace('\n', ' ').replace('\r', ' '));
         glyphPositions.clear();
         float x = 0;
         if(layout.runs.size > 0){
@@ -443,8 +443,9 @@ public class TextField extends Element implements Disableable{
                 glyphPositions.add(x);
                 x += xAdvances.get(i);
             }
-        }else
+        }else{
             fontOffset = 0;
+	}
         glyphPositions.add(x);
 
         visibleTextStart = Math.min(visibleTextStart, glyphPositions.size);


### PR DESCRIPTION
Fixed #122. Turns out this issue was fixed in LibGDX a long time ago, but arc didn't receive these fixes. (I still don't see a connection between the non-standard fonts and the incorrect calculations that they were only occurring with them)
![Miserable_situation_20220814_030201](https://user-images.githubusercontent.com/69920617/184517290-0813830e-d4ea-47ad-805d-f64d27533cc7.png)
