### PR TITLE
Rounding errors in float to string methods

### DIFF
--- a/arc-core/src/arc/util/Strings.java
+++ b/arc-core/src/arc/util/Strings.java
@@ -576,7 +576,7 @@ public class Strings{
         d = Math.abs(d);
         StringBuilder dec = tmp2;
         dec.setLength(0);
-        dec.append((int)(d * Math.pow(10, decimalPlaces) + 0.000001f));
+        dec.append((int)(float)(d * Math.pow(10, decimalPlaces) + 0.00001f));
 
         int len = dec.length();
         int decimalPosition = len - decimalPlaces;

--- a/arc-core/src/arc/util/Strings.java
+++ b/arc-core/src/arc/util/Strings.java
@@ -560,7 +560,8 @@ public class Strings{
     }
 
     public static String autoFixed(float value, int max){
-        int precision = Math.abs((int)value - value) <= 0.0001f ? 0 : Math.abs((int)(value * 10) - value * 10) <= 0.0001f ? 1 : 2;
+        int precision = Math.abs((int)(value + 0.0001f) - value) <= 0.0001f ? 0 :
+                Math.abs((int)(value * 10 + 0.0001f) - value * 10) <= 0.0001f ? 1 : 2;
         return fixed(value, Math.min(precision, max));
     }
 
@@ -576,7 +577,7 @@ public class Strings{
         d = Math.abs(d);
         StringBuilder dec = tmp2;
         dec.setLength(0);
-        dec.append((int)(float)(d * Math.pow(10, decimalPlaces) + 0.00001f));
+        dec.append((int)(float)(d * Math.pow(10, decimalPlaces) + 0.0001f));
 
         int len = dec.length();
         int decimalPosition = len - decimalPlaces;


### PR DESCRIPTION
I have made the float "formatter" (float to string) methods in `arc.util.Strings` less sensitive to small errors. They should provide more accurate results overall now. Specifically, I am discussing the `autoFixed()` and `fixedBuilder()` methods.

The fix I selected for this pull request is the one that keeps the rounding down behavior (section *Rounding down*), but I have other alternatives prepared.

## Issues

Currently, I find the float "formatters" too strict with rounding down, it gives little to no room for errors. This results in some numbers being 0.01 smaller than they should be.

Also, certain numbers like 4.2 display as 4.1 instead of more acceptable results such as 4.19 or 4.20. This specific number is used in stats for copper conveyor in Mindustry and was also used for the separator factory in v6. Disassembler factory has the same issue with number 7.2.

There are also numbers like 4.79 (laser drill water consumption) and 2.39 (thorium reactor cryofluid consumption), which are results of inaccurate calculations (0.08 * 60 = 4.7999997) and are technically displayed correctly. While not the main focus, having these numbers displayed as what they were supposed to be would be nice.

## Fixes

I mainly wanted to fix the issue with 4.2. I tried to make the fixes as minimal as possible to not accidentally break anything (although I do discuss changing the rounding used, which does have some consequences). So I ended up with a bunch of tweaks that do manage to fix the 4.2 and 4.79 issue, but some numbers directly on thresholds still get rounded incorrectly.

The most helpful change that is used in the fixes is the cast to float before finally casting to int in the `fixedBuilder()` method. It eliminates the inaccuracy that is introduced by widening the original float value to double quite nicely.

### Rounding half up

One way to "fix" the issues would be to change the rounding to the more commonly used half up rounding. In addition to fixing/hiding the issues above, I think using this rounding is more fit for displaying final numbers to people, since not many expect rounding down.

The main downside of this solution is its conflict with the "display flat numbers with less decimal places" feature. Suppose you have a constantly rising value. The output would be: 
```... 1.99, 2.00, 2, 2.00, 2.01...```
In game I have noticed this only when depositing into the core (10.0k items).

I did not add any measures to help with rounding 0.005 correctly.

### Rounding down

Since changing the rounding mode has some consequences, I also made an alternative fix that keeps the rounding down behavior. This does not seem to break anything, apart from the "other `autoFixed()`" in Mindustry (mentioned in a section below).

Some numbers may still get displayed incorrectly, albeit much less frequently. There are 2 types of these errors: 
1) 164.09999 displays as 164.10 
    - `AutoFixed()` expects 164.09, but `fixedBuilder()` produces 164.10, resulting in neither 164.09 nor 164.1.
2) 64.09 displays as 64.08
    - It gets rounded down even though it should stay unchanged.

Both these examples are the smallest numbers this can occur with, which is pretty great. On the other hand, numbers like 0.019999 get rounded up to 0.02 (not 0.01), which I also consider completely fine.

### About the other `autoFixed()`

Mindustry has its own method called `mindustry.world.meta.StatValues.fixValue()`, which is sometimes used instead of `autoFixed()`. Both are exactly the same, they only use different thresholds. Since both fixes change the `autoFixed()` method a bit, you would need to copy relevant changes to the `fixValue()` method, too, or simply use `autoFixed()` instead.

In case you do not want the fix to touch the `autoFixed()` method, I can use previous commit of the rounding down fix, but it will fix fewer situations.

## Final notes

In this pull request, I propose the rounding down fix, since I have to choose one and I do not have high hopes of the half up rounding getting accepted. I hope I can change which fix to propose afterwards somehow if you decide for one of the other options. This is my first pull request, so I do not know how exactly everything works yet.

I did test the changes, but mostly only through the `autoFixed()` method. I made a small program that tests all floats in a given range. I usually checked numbers up to 10000 and also briefly checked negative numbers. I also compiled and played the latest release (not commit) of Mindustry to see if something unexpected shows up.

Sorry for a wall of text about 2 lines of code.