### PR TITLE
Support of texture rescale

### DIFF
--- a/arc-core/src/arc/graphics/g2d/Draw.java
+++ b/arc-core/src/arc/graphics/g2d/Draw.java
@@ -4,6 +4,7 @@ import arc.*;
 import arc.func.*;
 import arc.graphics.*;
 import arc.graphics.gl.*;
+import arc.graphics.g2d.TextureAtlas.*;
 import arc.math.*;
 import arc.math.geom.*;
 import arc.util.*;
@@ -324,7 +325,7 @@ public class Draw{
     }
 
     public static void rect(TextureRegion region, float x, float y){
-        rect(region, x, y, region.width * scl * xscl, region.height * scl * yscl);
+        rect(region, x, y, 0);
     }
 
     public static void rect(String region, float x, float y){
@@ -335,8 +336,11 @@ public class Draw{
         Core.batch.draw(region, x - w /2f, y - h /2f, originX, originY, w, h, rotation);
     }
 
-    public static void rect(String region, float x, float y, float w, float h, float originX, float originY, float rotation){
-        Core.batch.draw(Core.atlas.find(region), x - w /2f, y - h /2f, originX, originY, w, h, rotation);
+    public static void rect(String regionName, float x, float y, float w, float h, float originX, float originY, float rotation){
+        AtlasRegion region = atlas.find(regionName);
+        w *= region.scale;
+        h *= region.scale;
+        Core.batch.draw(region, x - w /2f, y - h /2f, originX, originY, w, h, rotation);
     }
 
     public static void rect(TextureRegion region, float x, float y, float w, float h, float rotation){
@@ -344,7 +348,7 @@ public class Draw{
     }
 
     public static void rect(String region, float x, float y, float w, float h, float rotation){
-        rect(Core.atlas.find(region), x, y, w, h, w/2f, h/2f, rotation);
+        rect(Core.atlas.find(region), x, y, w, h, rotation);
     }
 
     public static void rect(TextureRegion region, Position pos, float w, float h){
@@ -360,7 +364,9 @@ public class Draw{
     }
 
     public static void rect(TextureRegion region, float x, float y, float rotation){
-        rect(region, x, y, region.width * scl * xscl, region.height * scl * yscl, rotation);
+        float w = region.width * xscl * region.scl();
+        float h = region.height * yscl * region.scl();
+        rect(region, x, y, w, h, rotation);
     }
 
     public static void rect(String region, float x, float y, float rotation){

--- a/arc-core/src/arc/graphics/g2d/Draw.java
+++ b/arc-core/src/arc/graphics/g2d/Draw.java
@@ -4,7 +4,6 @@ import arc.*;
 import arc.func.*;
 import arc.graphics.*;
 import arc.graphics.gl.*;
-import arc.graphics.g2d.TextureAtlas.*;
 import arc.math.*;
 import arc.math.geom.*;
 import arc.util.*;
@@ -325,7 +324,7 @@ public class Draw{
     }
 
     public static void rect(TextureRegion region, float x, float y){
-        rect(region, x, y, 0);
+        rect(region, x, y, region.width * region.scl() * xscl, region.height * region.scl() * yscl);
     }
 
     public static void rect(String region, float x, float y){
@@ -336,11 +335,8 @@ public class Draw{
         Core.batch.draw(region, x - w /2f, y - h /2f, originX, originY, w, h, rotation);
     }
 
-    public static void rect(String regionName, float x, float y, float w, float h, float originX, float originY, float rotation){
-        AtlasRegion region = atlas.find(regionName);
-        w *= region.scale;
-        h *= region.scale;
-        Core.batch.draw(region, x - w /2f, y - h /2f, originX, originY, w, h, rotation);
+    public static void rect(String region, float x, float y, float w, float h, float originX, float originY, float rotation){
+        Core.batch.draw(Core.atlas.find(region), x - w /2f, y - h /2f, originX, originY, w, h, rotation);
     }
 
     public static void rect(TextureRegion region, float x, float y, float w, float h, float rotation){
@@ -348,7 +344,7 @@ public class Draw{
     }
 
     public static void rect(String region, float x, float y, float w, float h, float rotation){
-        rect(Core.atlas.find(region), x, y, w, h, rotation);
+        rect(Core.atlas.find(region), x, y, w, h, w/2f, h/2f, rotation);
     }
 
     public static void rect(TextureRegion region, Position pos, float w, float h){
@@ -364,9 +360,7 @@ public class Draw{
     }
 
     public static void rect(TextureRegion region, float x, float y, float rotation){
-        float w = region.width * xscl * region.scl();
-        float h = region.height * yscl * region.scl();
-        rect(region, x, y, w, h, rotation);
+        rect(region, x, y, region.width * region.scl() * xscl, region.height * region.scl() * yscl, rotation);
     }
 
     public static void rect(String region, float x, float y, float rotation){

--- a/arc-core/src/arc/graphics/g2d/TextureRegion.java
+++ b/arc-core/src/arc/graphics/g2d/TextureRegion.java
@@ -3,6 +3,7 @@ package arc.graphics.g2d;
 import arc.*;
 import arc.graphics.*;
 import arc.graphics.g2d.TextureAtlas.AtlasRegion;
+import arc.graphics.g2d.Draw;
 
 /**
  * Defines a rectangular area of a texture. The coordinate system used has its origin in the upper left corner with the x-axis
@@ -17,6 +18,8 @@ public class TextureRegion{
     public float u, v, u2, v2;
     /** Read-only. Use setters to change. */
     public int width, height;
+
+    public float scale = 1.0f;
 
     /** Constructs a region with no texture and no coordinates defined. */
     public TextureRegion(){
@@ -132,6 +135,7 @@ public class TextureRegion{
     /** Sets the texture and coordinates to the specified region. */
     public void set(TextureRegion region){
         texture = region.texture;
+        scale = region.scale;
         u = region.u;
         v = region.v;
         u2 = region.u2;
@@ -143,6 +147,7 @@ public class TextureRegion{
     /** Sets the texture to that of the specified region and sets the coordinates relative to the specified region. */
     public void set(TextureRegion region, int x, int y, int width, int height){
         texture = region.texture;
+        scale = region.scale;
         set(region.getX() + x, region.getY() + y, width, height);
     }
 
@@ -297,6 +302,10 @@ public class TextureRegion{
         }
 
         return tiles;
+    }
+
+    public float scl(){
+        return scale * Draw.scl;
     }
 
     @Override


### PR DESCRIPTION
If you want a texture to be scaled everytime, just change its scale.
To bypass it, change the h and w when calling `Draw.rect`, as usual.