### PR TITLE
Make TextFormatter public

### DIFF
--- a/arc-core/src/arc/util/TextFormatter.java
+++ b/arc-core/src/arc/util/TextFormatter.java
@@ -7,7 +7,7 @@ import java.util.Locale;
  * {@code TextFormatter} is used by {@link I18NBundle} to perform argument replacement.
  * @author davebaol
  */
-class TextFormatter{
+public class TextFormatter{
 
     private MessageFormat messageFormat;
     private StringBuilder buffer;


### PR DESCRIPTION
why? Because it might be very useful to make custom not I18N bundles