### PR TITLE
Arc fill/line fix

### DIFF
--- a/arc-core/src/arc/graphics/g2d/Fill.java
+++ b/arc-core/src/arc/graphics/g2d/Fill.java
@@ -259,7 +259,7 @@ public class Fill{
     }
 
     public static void arc(float x, float y, float radius, float fraction, float rotation, int sides){
-        int max = (int)(sides * fraction);
+        int max = Mathf.ceil(sides * fraction);
         polyBegin();
         polyPoint(x, y);
         

--- a/arc-core/src/arc/graphics/g2d/Lines.java
+++ b/arc-core/src/arc/graphics/g2d/Lines.java
@@ -411,7 +411,7 @@ public class Lines{
     }
 
     public static void arc(float x, float y, float radius, float fraction, float rotation, int sides){
-        int max = (int)(sides * fraction);
+        int max = Mathf.ceil(sides * fraction);
         floats.clear();
 
         for(int i = 0; i <= max; i++){


### PR DESCRIPTION
A small enough fraction would result in max being rounded down to 0, thus not drawing an arc.