### PR TITLE
Fix alpha blending mode

### DIFF
--- a/arc-core/src/arc/graphics/Blending.java
+++ b/arc-core/src/arc/graphics/Blending.java
@@ -3,9 +3,9 @@ package arc.graphics;
 /** Blending modes, can be instantiated to make custom blending. */
 public class Blending{
     public static final Blending
-    normal = new Blending(Gl.srcAlpha, Gl.oneMinusSrcAlpha),
-    additive = new Blending(Gl.srcAlpha, Gl.one),
-    disabled = new Blending(Gl.srcAlpha, Gl.oneMinusSrcAlpha){
+    normal = new Blending(Gl.srcAlpha, Gl.oneMinusSrcAlpha, Gl.one, Gl.oneMinusSrcAlpha),
+    additive = new Blending(Gl.srcAlpha, Gl.one, Gl.one, Gl.oneMinusSrcAlpha),
+    disabled = new Blending(Gl.srcAlpha, Gl.oneMinusSrcAlpha, Gl.one, Gl.oneMinusSrcAlpha){
         @Override
         public void apply(){
             Gl.disable(Gl.blend);


### PR DESCRIPTION
# Before
Dark edges between floors, due to the alpha not being `1f` for some reason.
![image](https://github.com/Anuken/Arc/assets/63218676/671b9b03-5c37-412f-bfec-dd82c451e6fc)

# After
Nice-looking floors.
![image](https://github.com/Anuken/Arc/assets/63218676/072e3159-80ae-49d0-b32c-8b6e84653b02)

## Context
Currently, `Blending.normal` has both `Gl.srcAlpha` for source color and source alpha. While this makes it correctly interpolate the color components (`src.a * src.rgb + (1f - src.a) * dst.rgb`), this incorrectly interpolates the alpha component (`src.a * src.a + (1f - src.a) * dst.a`).
This PR changes the source alpha to `Gl.one`, and turns the alpha calculation into `1f * src.a + (1f - src.a) * dst.a` (e.g., for `src.a = 0.5f` and `dst.a = 1f`, as such is the case for drawing transparent sprites on top of opaque sprites, the result is `0.5f + (1f - 0.5f) * 1f = 1f` _(still opaque)_ instead of `0.5f * 0.5f + (1f - 0.5f) * 1f = 0.75f` _(becomes transparent for some reason)_).