### PR TITLE
Add backslash key

### DIFF
--- a/backends/backend-sdl/src/arc/backend/sdl/SdlScanmap.java
+++ b/backends/backend-sdl/src/arc/backend/sdl/SdlScanmap.java
@@ -50,6 +50,7 @@ public class SdlScanmap{
             case 206: return KeyCode.at;
             case 47: return KeyCode.leftBracket;
             case 48: return KeyCode.rightBracket;
+            case 100:
             case 49: return KeyCode.backslash;
             case 53: return KeyCode.backtick;
             case 4: return KeyCode.a;


### PR DESCRIPTION
Keyboards can have an extra backslash called IntlBackslash. IntlBackslash and a regular Backslash are the same symbol. This PR binds its KeyCode to a backslash ![keyboard with IntlBackslash](https://github.com/Anuken/Arc/assets/118817903/d56b7a2e-cbf9-43c6-8574-db8628941951)

Debug images:
Image 1. Try to rebind key in stock game 
<img width="875" alt="debug1" src="https://github.com/Anuken/Arc/assets/118817903/706e56ff-5b41-4c41-b38b-6b53d9b17ee7">

Image 2. For key==100 (IntlBackslash) result is _Unknown_
<img width="876" alt="debug2" src="https://github.com/Anuken/Arc/assets/118817903/a2da2291-6702-4a25-87a1-5c767f9ce662">

Image 3. Result after changes 
<img width="877" alt="debug3" src="https://github.com/Anuken/Arc/assets/118817903/53e4af90-18d6-49ef-8ec3-fb0fbd3d3aec">
