### PR TITLE
fix artifact upload in natives.yml

### DIFF
--- a/.github/workflows/natives.yml
+++ b/.github/workflows/natives.yml
@@ -21,7 +21,7 @@ jobs:
           ./gradlew extensions:freetype:jnigenBuild
           ./gradlew backends:backend-sdl:jnigenBuild
       - name: Upload natives
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Arc-core desktop natives
           path: |
@@ -35,7 +35,7 @@ jobs:
             natives/natives-freetype-desktop/libs/arc-freetype.dll
             natives/natives-freetype-desktop/libs/arc-freetype64.dll
       - name: Upload Android natives
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Arc-core android natives
           path: |
@@ -61,7 +61,7 @@ jobs:
           ./gradlew extensions:freetype:jnigenBuild
           ./gradlew backends:backend-sdl:jnigenBuild
       - name: Upload natives
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Arc-core MacOS natives
           path: |
@@ -72,7 +72,7 @@ jobs:
             backends/backend-sdl/libs/macosx64/libsdl-arc64.dylib
             backends/backend-sdl/libs/macosx64/libsdl-arcarm64.dylib
       - name: Upload iOS natives
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Arc-core iOS natives
           path: |


### PR DESCRIPTION
The v2 of `upload-artifact` has been deprecated for some time [now](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/), making the "Build Natives" action failing. I bumped the version to v4.