### PR TITLE
Fix MRT and clean-up cubemap FBOs

### DIFF
--- a/arc-core/src/arc/graphics/Cubemap.java
+++ b/arc-core/src/arc/graphics/Cubemap.java
@@ -119,6 +119,9 @@ public class Cubemap extends GLTexture{
         /** The negative Z and sixth side of the cubemap */
         negativeZ(5, GL20.GL_TEXTURE_CUBE_MAP_NEGATIVE_Z, 0, -1, 0, 0, 0, -1);
 
+        /** Cached {@link CubemapSide#values()} for performance and ergonomics. */
+        public static final CubemapSide[] all = values();
+
         /** The zero based index of the side in the cubemap */
         public final int index;
         /** The OpenGL target (used for glTexImage2D) of the side. */

--- a/arc-core/src/arc/graphics/gl/FrameBuffer.java
+++ b/arc-core/src/arc/graphics/gl/FrameBuffer.java
@@ -139,12 +139,12 @@ public class FrameBuffer extends GLFrameBuffer<Texture>{
     }
 
     @Override
-    protected void disposeColorTexture(Texture colorTexture){
+    protected void disposeTexture(Texture colorTexture){
         colorTexture.dispose();
     }
 
     @Override
-    protected void attachFrameBufferColorTexture(Texture texture){
-        Gl.framebufferTexture2D(Gl.framebuffer, GL20.GL_COLOR_ATTACHMENT0, GL20.GL_TEXTURE_2D, texture.getTextureObjectHandle(), 0);
+    protected void attachTexture(int attachment, Texture texture){
+        Gl.framebufferTexture2D(Gl.framebuffer, attachment, Gl.texture2d, texture.getTextureObjectHandle(), 0);
     }
 }


### PR DESCRIPTION
- Made `CubemapSide.all = values()`.
- Completely remove `FrameBufferCubemap`'s `nextSide()` as it completely chokes when another FBO is bound while it is already bound, causing `currentSide` to go back to -1 when it is rebound, resulting in an eternal while-loop.
- Refactored:
  - `disposeColorTexture()` ->`disposeTexture()`
  - `attachFrameBufferColorTexture()` -> `attachTexture()` with an attachment parameter, e.g. `Gl.colorAttachment0` and `Gl.depthAttachment`