### PR TITLE
removed unneccesary toLowerCase() in ComandHandler.register

### DIFF
--- a/arc-core/src/arc/util/CommandHandler.java
+++ b/arc-core/src/arc/util/CommandHandler.java
@@ -116,7 +116,7 @@ public class CommandHandler{
         orderedCommands.remove(c -> c.text.equals(text));
 
         Command cmd = new Command(text, params, description, runner);
-        commands.put(text.toLowerCase(), cmd);
+        commands.put(text, cmd);
         orderedCommands.add(cmd);
         return cmd;
     }


### PR DESCRIPTION
why was it there in the first place