### PR TITLE
Events options to allow listening to events only once

### DIFF
--- a/arc-core/src/arc/Events.java
+++ b/arc-core/src/arc/Events.java
@@ -8,7 +8,7 @@ import arc.func.Cons;
 /** Simple global event listener system. */
 @SuppressWarnings("unchecked")
 public class Events{
-    private static final ObjectMap<Object, Seq<Cons<?>>> events = new ObjectMap<>();
+    private static final ObjectMap<Object, Seq<Cons<?>>> events = new ObjectMap<>(), onceEvents = new ObjectMap<>();
 
     /** Handle an event by class. */
     public static <T> void on(Class<T> type, Cons<T> listener){
@@ -18,6 +18,16 @@ public class Events{
     /** Handle an event by enum trigger. */
     public static void run(Object type, Runnable listener){
         events.get(type, () -> new Seq<>(Cons.class)).add(e -> listener.run());
+    }
+
+    /** Handle an event by class once. */
+    public static <T> void once(Class<T> type, Cons<T> listener){
+        onceEvents.get(type, () -> new Seq<>(Cons.class)).add(listener);
+    }
+
+    /** Handle an event by enum trigger once. */
+    public static void runOnce(Object type, Runnable listener){
+        onceEvents.get(type, () -> new Seq<>(Cons.class)).add(e -> listener.run());
     }
 
     /** Only use this method if you have the reference to the exact listener object that was used. */
@@ -44,7 +54,7 @@ public class Events{
     }
 
     public static <T> void fire(Class<?> ctype, T type){
-        Seq<Cons<?>> listeners = events.get(ctype);
+        Seq<Cons<?>> listeners = events.get(ctype), onceListeners = onceEvents.get(ctype);
 
         if(listeners != null){
             int len = listeners.size;
@@ -53,10 +63,20 @@ public class Events{
                 items[i].get(type);
             }
         }
+
+        if(onceListeners != null){
+            int len = onceListeners.size;
+            Cons[] items = onceListeners.items;
+            for(int i = 0; i < len; i++){
+                items[i].get(type);
+            }
+            onceListeners.clear();
+        }
     }
 
     /** Don't do this. */
     public static void clear(){
         events.clear();
+        onceEvents.clear();
     }
 }


### PR DESCRIPTION
new methods for Events:

`once` - handle an event by class only once
`runOnce` - handle an event by enum trigger only once