### PR TITLE
Disallow opening empty URIs

### DIFF
--- a/backends/backend-sdl/src/arc/backend/sdl/SdlApplication.java
+++ b/backends/backend-sdl/src/arc/backend/sdl/SdlApplication.java
@@ -276,6 +276,7 @@ public class SdlApplication implements Application{
     public boolean openURI(String url){
 
         //make sure it's a valid URI
+        if(url.isEmpty()) return false;
         try{
             URI.create(url);
         }catch(Exception wrong){


### PR DESCRIPTION
For some reason URI.create() accepts the empty string as a valid URI. Currently, calling Core.app.openURI() with an empty string returns `true`, as if it succeeded, and it runs `xdg-open` with no arguments, printing an error message to the console.
It should return `false`.