### PR TITLE
Fix collection shrink hanging

### DIFF
--- a/arc-core/src/arc/struct/IntFloatMap.java
+++ b/arc-core/src/arc/struct/IntFloatMap.java
@@ -327,6 +327,7 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry>{
      */
     public void shrink(int maximumCapacity){
         if(maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+        if(size > maximumCapacity) maximumCapacity = size;
         int tableSize = tableSize(maximumCapacity, loadFactor);
         if(keyTable.length > tableSize) resize(tableSize);
     }

--- a/arc-core/src/arc/struct/IntIntMap.java
+++ b/arc-core/src/arc/struct/IntIntMap.java
@@ -318,6 +318,7 @@ public class IntIntMap implements Iterable<IntIntMap.Entry>{
      */
     public void shrink(int maximumCapacity){
         if(maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+        if(size > maximumCapacity) maximumCapacity = size;
         int tableSize = tableSize(maximumCapacity, loadFactor);
         if(keyTable.length > tableSize) resize(tableSize);
     }

--- a/arc-core/src/arc/struct/IntMap.java
+++ b/arc-core/src/arc/struct/IntMap.java
@@ -271,6 +271,7 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>>{
      */
     public void shrink(int maximumCapacity){
         if(maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+        if(size > maximumCapacity) maximumCapacity = size;
         int tableSize = tableSize(maximumCapacity, loadFactor);
         if(keyTable.length > tableSize) resize(tableSize);
     }

--- a/arc-core/src/arc/struct/IntSet.java
+++ b/arc-core/src/arc/struct/IntSet.java
@@ -222,6 +222,7 @@ public class IntSet{
      */
     public void shrink(int maximumCapacity){
         if(maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+        if(size > maximumCapacity) maximumCapacity = size;
         int tableSize = tableSize(maximumCapacity, loadFactor);
         if(keyTable.length > tableSize) resize(tableSize);
     }

--- a/arc-core/src/arc/struct/LongMap.java
+++ b/arc-core/src/arc/struct/LongMap.java
@@ -250,6 +250,7 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>>{
      */
     public void shrink(int maximumCapacity){
         if(maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+        if(size > maximumCapacity) maximumCapacity = size;
         int tableSize = tableSize(maximumCapacity, loadFactor);
         if(keyTable.length > tableSize) resize(tableSize);
     }

--- a/arc-core/src/arc/struct/ObjectFloatMap.java
+++ b/arc-core/src/arc/struct/ObjectFloatMap.java
@@ -280,6 +280,7 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>>{
      */
     public void shrink(int maximumCapacity){
         if(maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+        if(size > maximumCapacity) maximumCapacity = size;
         int tableSize = tableSize(maximumCapacity, loadFactor);
         if(keyTable.length > tableSize) resize(tableSize);
     }

--- a/arc-core/src/arc/struct/ObjectIntMap.java
+++ b/arc-core/src/arc/struct/ObjectIntMap.java
@@ -287,6 +287,7 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>>{
      */
     public void shrink(int maximumCapacity){
         if(maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+        if(size > maximumCapacity) maximumCapacity = size;
         int tableSize = tableSize(maximumCapacity, loadFactor);
         if(keyTable.length > tableSize) resize(tableSize);
     }

--- a/arc-core/src/arc/struct/ObjectMap.java
+++ b/arc-core/src/arc/struct/ObjectMap.java
@@ -283,6 +283,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>>{
      */
     public void shrink(int maximumCapacity){
         if(maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+        if(size > maximumCapacity) maximumCapacity = size;
         int tableSize = tableSize(maximumCapacity, loadFactor);
         if(keyTable.length > tableSize) resize(tableSize);
     }

--- a/arc-core/src/arc/struct/ObjectSet.java
+++ b/arc-core/src/arc/struct/ObjectSet.java
@@ -278,6 +278,7 @@ public class ObjectSet<T> implements Iterable<T>, Eachable<T>{
      */
     public void shrink(int maximumCapacity){
         if(maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+        if(size > maximumCapacity) maximumCapacity = size;
         int tableSize = tableSize(maximumCapacity, loadFactor);
         if(keyTable.length > tableSize) resize(tableSize);
     }


### PR DESCRIPTION
Fixes collection hanging (Anuken/Mindustry#12303)

This just re-adds the check for size > capacity that was removed while syncing collections.

