### PR TITLE
Update jnigen-gradle to 3.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript{
     }
 
     dependencies{
-        classpath "com.badlogicgames.jnigen:jnigen-gradle:3.1.1"
+        classpath "com.badlogicgames.jnigen:jnigen-gradle:3.1.2"
     }
 }
 


### PR DESCRIPTION
This includes the fix:
https://github.com/libgdx/gdx-jnigen/commit/6b08c78

Which is needed on NixOS because the normal gcc needs a wrapper script which is injected using an override in the PATH variable.