### PR TITLE
Handle Long.MIN_VALUE in formatMillis

### DIFF
--- a/arc-core/src/arc/util/Strings.java
+++ b/arc-core/src/arc/util/Strings.java
@@ -1,5 +1,7 @@
 package arc.util;
 
+import java.math.BigInteger;
+
 import arc.graphics.*;
 import arc.math.*;
 import arc.struct.*;
@@ -764,16 +766,15 @@ public class Strings{
 
     public static String formatMillis(long val){
         StringBuilder buf = new StringBuilder(20);
-        String sgn = "";
+        BigInteger millis = BigInteger.valueOf(val);
+        String sgn = millis.signum() < 0 ? "-" : "";
+        millis = millis.abs();
 
-        if(val < 0) sgn = "-";
-        val = Math.abs(val);
-
-        append(buf, sgn, 0, (val / 3600000));
-        val %= 3600000;
-        append(buf, ":", 2, (val / 60000));
-        val %= 60000;
-        append(buf, ":", 2, (val / 1000));
+        BigInteger[] hours = millis.divideAndRemainder(BigInteger.valueOf(3600000));
+        BigInteger[] minutes = hours[1].divideAndRemainder(BigInteger.valueOf(60000));
+        append(buf, sgn, 0, hours[0].longValue());
+        append(buf, ":", 2, minutes[0].longValue());
+        append(buf, ":", 2, minutes[1].divide(BigInteger.valueOf(1000)).longValue());
         return buf.toString();
     }
 

--- a/arc-core/test/StringsTest.java
+++ b/arc-core/test/StringsTest.java
@@ -52,6 +52,11 @@ public class StringsTest{
         assertEquals(Strings.sanitizeFilename("..txt"), "..txt");
     }
 
+    @Test
+    public void testFormatMillisHandlesLongMinValue(){
+        assertEquals("-2562047788015:12:55", Strings.formatMillis(Long.MIN_VALUE));
+    }
+
     static void checkDouble(String value){
         assertEquals(Double.parseDouble(value), Strings.parseDouble(value, 999999), 0.00001);
     }


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/6711693.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Use an exact absolute-value representation when formatting negative durations so Long.MIN_VALUE no longer overflows.

<!-- Include the Testing section only when a relevant test exists and was run. Otherwise remove this comment and the entire section below. -->
## Testing

`./gradlew arc-core:test --tests StringsTest`

Result: Passed
