### PR TITLE
Fix table rounding issues when row/col heights are not integers

### DIFF
--- a/arc-core/src/arc/scene/ui/layout/Table.java
+++ b/arc-core/src/arc/scene/ui/layout/Table.java
@@ -1045,6 +1045,18 @@ public class Table extends WidgetGroup{
             }
         }
 
+        // Round before accumulating so that rounding drift doesn't occur.
+        if(round){
+            for(int i = 0; i < columns; i++){
+                columnMinWidth[i] = Math.round(columnMinWidth[i]);
+                columnPrefWidth[i] = Math.round(columnPrefWidth[i]);
+            }
+            for(int i = 0; i < rows; i++){
+                rowMinHeight[i] = Math.round(rowMinHeight[i]);
+                rowPrefHeight[i] = Math.round(rowPrefHeight[i]);
+            }
+        }
+
         // Determine table min and pref size.
         tableMinWidth = 0;
         tableMinHeight = 0;
@@ -1199,6 +1211,12 @@ public class Table extends WidgetGroup{
                 for(int column = c.column, nn = column + colspan; column < nn; column++)
                     columnWidth[column] += extraWidth;
             }
+        }
+
+        // Round before accumulating so that rounding drift doesn't occur.
+        if(round){
+            for(int i = 0; i < columns; i++) columnWidth[i] = Math.round(columnWidth[i]);
+            for(int i = 0; i < rows; i++) rowHeight[i] = Math.round(rowHeight[i]);
         }
 
         // Determine table size.


### PR DESCRIPTION
This is mostly something that happens with ui scaling set to non 100%. In this example, I used 55%.
As you can see, by the before and after numerous issues:"
- Overlapping category icons due to rounding to the nearest pixel after accumulating offsets
- The top border of the block placement ui being [raised by 1 pixel](https://github.com/user-attachments/assets/d05d17e2-e4ad-4ca7-8640-c1f60c4fed2a) for the same reasons.
- The entire menu jumping around when hovering between display types with different margins (building and ore (tile) in this demo)

[Before](https://github.com/user-attachments/assets/d9e98746-16c5-4295-94f6-751d0cfa2c3e)
[After](https://github.com/user-attachments/assets/f1f7306b-673e-4225-9ad6-96eab76064d1)

The bottom border is still scuffed but that's just because it's seemingly 2 pixels tall on the left(?) and only one on the right and isn't something that this pr will fix (not that it can considering that it's a mindustry issue).


See https://github.com/Anuken/Mindustry/pull/12515 for other consequences of this PR. Hopefully there aren't a bunch of these.