### PR TITLE
Allow event listeners to specify a priority

### DIFF
--- a/arc-core/src/arc/Events.java
+++ b/arc-core/src/arc/Events.java
@@ -40,7 +40,7 @@ public class Events{
                 .sort(comparator);
     }
 
-    /** Only use this method if you have the reference to the exact listener object that was used. */
+    /** Removes the event listener from the specified event type. */
     public static <T> boolean remove(Class<T> type, Cons<T> listener){
         Seq<Cons<?>> listeners = events.get(type);
         if (listeners == null){

--- a/arc-core/src/arc/Events.java
+++ b/arc-core/src/arc/Events.java
@@ -4,13 +4,14 @@ package arc;
 import arc.struct.Seq;
 import arc.struct.ObjectMap;
 import arc.func.Cons;
+import arc.struct.SnapshotSeq;
 import arc.util.Priority;
 import java.util.Comparator;
 
 /** Simple global event listener system. */
 @SuppressWarnings("unchecked")
 public class Events{
-    private static final ObjectMap<Object, Seq<Cons<?>>> events = new ObjectMap<>();
+    private static final ObjectMap<Object, SnapshotSeq<Cons<?>>> events = new ObjectMap<>();
     private static final Comparator<Cons<?>> comparator = (a, b) -> {
         Priority priorityA = a instanceof ConsWithPriority ? ((ConsWithPriority<?>)a).priority : Priority.normal;
         Priority priorityB = b instanceof ConsWithPriority ? ((ConsWithPriority<?>)b).priority : Priority.normal;
@@ -24,7 +25,7 @@ public class Events{
 
     /** Handle an event by class with the specified priority. */
     public static <T> void on(Class<T> type, Priority priority, Cons<T> listener){
-        events.get(type, () -> new Seq<>(Cons.class))
+        events.get(type, () -> new SnapshotSeq<>(Cons.class))
                 .add(priority == Priority.normal ? listener : new ConsWithPriority<>(listener, priority))
                 .sort(comparator);
     }
@@ -36,7 +37,7 @@ public class Events{
 
     /** Handle an event by enum trigger with the specified priority. */
     public static void run(Object type, Priority priority, Runnable listener){
-        events.get(type, () -> new Seq<>(Cons.class))
+        events.get(type, () -> new SnapshotSeq<>(Cons.class))
                 .add(priority == Priority.normal ? e -> listener.run() : new ConsWithPriority<>(e -> listener.run(), priority))
                 .sort(comparator);
     }
@@ -58,14 +59,18 @@ public class Events{
 
     /** Fires an enum trigger. */
     public static <T extends Enum<T>> void fire(Enum<T> type){
-        Seq<Cons<?>> listeners = events.get(type);
-
-        if(listeners != null){
+        SnapshotSeq<Cons<?>> listeners = events.get(type);
+        if(listeners == null){
+            return;
+        }
+        try{
             int len = listeners.size;
-            Cons[] items = listeners.items;
+            Cons[] items = listeners.begin();
             for(int i = 0; i < len; i++){
                 items[i].get(type);
             }
+        }finally{
+            listeners.end();
         }
     }
 
@@ -75,14 +80,18 @@ public class Events{
     }
 
     public static <T> void fire(Class<?> ctype, T type){
-        Seq<Cons<?>> listeners = events.get(ctype);
-
-        if(listeners != null){
+        SnapshotSeq<Cons<?>> listeners = events.get(ctype);
+        if(listeners == null){
+            return;
+        }
+        try{
             int len = listeners.size;
-            Cons[] items = listeners.items;
+            Cons[] items = listeners.begin();
             for(int i = 0; i < len; i++){
                 items[i].get(type);
             }
+        }finally{
+            listeners.end();
         }
     }
 

--- a/arc-core/src/arc/Events.java
+++ b/arc-core/src/arc/Events.java
@@ -42,7 +42,17 @@ public class Events{
 
     /** Only use this method if you have the reference to the exact listener object that was used. */
     public static <T> boolean remove(Class<T> type, Cons<T> listener){
-        return events.get(type, () -> new Seq<>(Cons.class)).remove(listener);
+        Seq<Cons<?>> listeners = events.get(type);
+        if (listeners == null){
+            return false;
+        }
+        return listeners.remove(l -> {
+            if(l instanceof ConsWithPriority<?>){
+                return ((ConsWithPriority<?>) l).cons.equals(listener);
+            }else{
+                return l.equals(listener);
+            }
+        });
     }
 
     /** Fires an enum trigger. */

--- a/arc-core/src/arc/Events.java
+++ b/arc-core/src/arc/Events.java
@@ -4,6 +4,7 @@ package arc;
 import arc.struct.Seq;
 import arc.struct.ObjectMap;
 import arc.func.Cons;
+import arc.util.Priority;
 import java.util.Comparator;
 
 /** Simple global event listener system. */

--- a/arc-core/src/arc/Events.java
+++ b/arc-core/src/arc/Events.java
@@ -4,20 +4,40 @@ package arc;
 import arc.struct.Seq;
 import arc.struct.ObjectMap;
 import arc.func.Cons;
+import java.util.Comparator;
 
 /** Simple global event listener system. */
 @SuppressWarnings("unchecked")
 public class Events{
     private static final ObjectMap<Object, Seq<Cons<?>>> events = new ObjectMap<>();
+    private static final Comparator<Cons<?>> comparator = (a, b) -> {
+        Priority priorityA = a instanceof ConsWithPriority ? ((ConsWithPriority<?>)a).priority : Priority.normal;
+        Priority priorityB = b instanceof ConsWithPriority ? ((ConsWithPriority<?>)b).priority : Priority.normal;
+        return priorityA.compareTo(priorityB);
+    };
 
     /** Handle an event by class. */
     public static <T> void on(Class<T> type, Cons<T> listener){
-        events.get(type, () -> new Seq<>(Cons.class)).add(listener);
+        on(type, Priority.normal, listener);
+    }
+
+    /** Handle an event by class with the specified priority. */
+    public static <T> void on(Class<T> type, Priority priority, Cons<T> listener){
+        events.get(type, () -> new Seq<>(Cons.class))
+                .add(priority == Priority.normal ? listener : new ConsWithPriority<>(listener, priority))
+                .sort(comparator);
     }
 
     /** Handle an event by enum trigger. */
     public static void run(Object type, Runnable listener){
-        events.get(type, () -> new Seq<>(Cons.class)).add(e -> listener.run());
+        run(type, Priority.normal, listener);
+    }
+
+    /** Handle an event by enum trigger with the specified priority. */
+    public static void run(Object type, Priority priority, Runnable listener){
+        events.get(type, () -> new Seq<>(Cons.class))
+                .add(priority == Priority.normal ? e -> listener.run() : new ConsWithPriority<>(e -> listener.run(), priority))
+                .sort(comparator);
     }
 
     /** Only use this method if you have the reference to the exact listener object that was used. */
@@ -58,5 +78,20 @@ public class Events{
     /** Don't do this. */
     public static void clear(){
         events.clear();
+    }
+
+    private static final class ConsWithPriority<T> implements Cons<T>{
+        private final Cons<T> cons;
+        private final Priority priority;
+
+        private ConsWithPriority(Cons<T> cons, Priority priority){
+            this.cons = cons;
+            this.priority = priority;
+        }
+
+        @Override
+        public void get(T t) {
+            this.cons.get(t);
+        }
     }
 }

--- a/arc-core/src/arc/Events.java
+++ b/arc-core/src/arc/Events.java
@@ -44,6 +44,15 @@ public class Events{
 
     /** Removes the event listener from the specified event type. */
     public static <T> boolean remove(Class<T> type, Cons<T> listener){
+        return remove0(type, listener);
+    }
+
+    /** Removes the event listener from the specified event type. */
+    public static <T> boolean remove(T type, Cons<T> listener){
+        return remove0(type, listener);
+    }
+
+    private static boolean remove0(Object type, Cons<?> listener){
         Seq<Cons<?>> listeners = events.get(type);
         if (listeners == null){
             return false;

--- a/arc-core/src/arc/Events.java
+++ b/arc-core/src/arc/Events.java
@@ -38,21 +38,14 @@ public class Events{
     /** Handle an event by enum trigger with the specified priority. */
     public static void run(Object type, Priority priority, Runnable listener){
         events.get(type, () -> new SnapshotSeq<>(Cons.class))
-                .add(priority == Priority.normal ? e -> listener.run() : new ConsWithPriority<>(e -> listener.run(), priority))
+                .add(priority == Priority.normal
+                        ? new ConsWithRunnable<>(listener)
+                        : new ConsWithPriority<>(new ConsWithRunnable<>(listener), priority))
                 .sort(comparator);
     }
 
     /** Removes the event listener from the specified event type. */
     public static <T> boolean remove(Class<T> type, Cons<T> listener){
-        return remove0(type, listener);
-    }
-
-    /** Removes the event listener from the specified event type. */
-    public static <T> boolean remove(T type, Cons<T> listener){
-        return remove0(type, listener);
-    }
-
-    private static boolean remove0(Object type, Cons<?> listener){
         Seq<Cons<?>> listeners = events.get(type);
         if (listeners == null){
             return false;
@@ -63,6 +56,23 @@ public class Events{
             }else{
                 return l.equals(listener);
             }
+        });
+    }
+
+    /** Removes the event listener from the specified event type. */
+    public static <T> boolean remove(T type, Runnable listener){
+        Seq<Cons<?>> listeners = events.get(type);
+        if (listeners == null){
+            return false;
+        }
+        return listeners.remove(l -> {
+            if(l instanceof ConsWithPriority<?>){
+                l = ((ConsWithPriority<?>) l).cons;
+            }
+            if(l instanceof ConsWithRunnable<?>){
+                return ((ConsWithRunnable<?>)l).runnable.equals(listener);
+            }
+            return false;
         });
     }
 
@@ -121,6 +131,19 @@ public class Events{
         @Override
         public void get(T t) {
             this.cons.get(t);
+        }
+    }
+
+    private static final class ConsWithRunnable<T> implements Cons<T>{
+        private final Runnable runnable;
+
+        private ConsWithRunnable(Runnable runnable){
+            this.runnable = runnable;
+        }
+
+        @Override
+        public void get(T t){
+            this.runnable.run();
         }
     }
 }

--- a/arc-core/src/arc/Events.java
+++ b/arc-core/src/arc/Events.java
@@ -6,6 +6,7 @@ import arc.struct.ObjectMap;
 import arc.func.Cons;
 import arc.struct.SnapshotSeq;
 import arc.util.Priority;
+
 import java.util.Comparator;
 
 /** Simple global event listener system. */
@@ -47,12 +48,12 @@ public class Events{
     /** Removes the event listener from the specified event type. */
     public static <T> boolean remove(Class<T> type, Cons<T> listener){
         Seq<Cons<?>> listeners = events.get(type);
-        if (listeners == null){
+        if(listeners == null){
             return false;
         }
         return listeners.remove(l -> {
             if(l instanceof ConsWithPriority<?>){
-                return ((ConsWithPriority<?>) l).cons.equals(listener);
+                return ((ConsWithPriority<?>)l).cons.equals(listener);
             }else{
                 return l.equals(listener);
             }
@@ -62,12 +63,12 @@ public class Events{
     /** Removes the event listener from the specified event type. */
     public static <T> boolean remove(T type, Runnable listener){
         Seq<Cons<?>> listeners = events.get(type);
-        if (listeners == null){
+        if(listeners == null){
             return false;
         }
         return listeners.remove(l -> {
             if(l instanceof ConsWithPriority<?>){
-                l = ((ConsWithPriority<?>) l).cons;
+                l = ((ConsWithPriority<?>)l).cons;
             }
             if(l instanceof ConsWithRunnable<?>){
                 return ((ConsWithRunnable<?>)l).runnable.equals(listener);
@@ -129,7 +130,7 @@ public class Events{
         }
 
         @Override
-        public void get(T t) {
+        public void get(T t){
             this.cons.get(t);
         }
     }

--- a/arc-core/src/arc/Priority.java
+++ b/arc-core/src/arc/Priority.java
@@ -1,0 +1,12 @@
+package arc;
+
+/**
+ * Utility class for ordering elements by priority.
+ */
+public enum Priority {
+    highest,
+    high,
+    normal,
+    low,
+    lowest
+}

--- a/arc-core/src/arc/Priority.java
+++ b/arc-core/src/arc/Priority.java
@@ -1,8 +1,6 @@
 package arc;
 
-/**
- * Utility class for ordering elements by priority.
- */
+/** Utility class for ordering elements by priority. */
 public enum Priority {
     highest,
     high,

--- a/arc-core/src/arc/util/Priority.java
+++ b/arc-core/src/arc/util/Priority.java
@@ -1,4 +1,4 @@
-package arc;
+package arc.util;
 
 /** Utility class for ordering elements by priority. */
 public enum Priority {

--- a/arc-core/src/arc/util/Priority.java
+++ b/arc-core/src/arc/util/Priority.java
@@ -1,7 +1,7 @@
 package arc.util;
 
 /** Utility class for ordering elements by priority. */
-public enum Priority {
+public enum Priority{
     highest,
     high,
     normal,


### PR DESCRIPTION
Sometimes, you need to ensure custom event listeners run before any game event listeners, and vice-versa.

This PR implements this by allowing event listeners to specify a `Priority`.

> A crude port of https://github.com/xpdustry/distributor/blob/5495003b22afae8e412b9a2904fb3da64d7e1880/distributor-common/src/main/java/com/xpdustry/distributor/common/event/EventBusImpl.java