### PR TITLE
Better context for custom loggers

### DIFF
--- a/arc-core/src/arc/util/Log.java
+++ b/arc-core/src/arc/util/Log.java
@@ -1,8 +1,5 @@
 package arc.util;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-
 public class Log{
     private static final Object[] empty = {};
 
@@ -12,64 +9,73 @@ public class Log{
     public static LogFormatter formatter = new DefaultLogFormatter();
 
     public static void log(LogLevel level, String text, Object... args){
-        if(Log.level.ordinal() > level.ordinal()) return;
-        logger.log(level, format(text, args));
+        if(isLevelMoreThan(level)) return;
+        logger.log(level, "", text, args);
+    }
+
+    public static void logTag(LogLevel level, String tag, String text, Object... args){
+        if(isLevelMoreThan(level)) return;
+        logger.log(level, tag, text, args);
     }
 
     public static void debug(String text, Object... args){
-        log(LogLevel.debug, text, args);
+        if(isLevelMoreThan(LogLevel.debug)) return;
+        logger.log(LogLevel.debug, "", text, args);
     }
     
     public static void debug(Object object){
-        debug(String.valueOf(object), empty);
+        if(isLevelMoreThan(LogLevel.debug)) return;
+        logger.log(LogLevel.debug, "", String.valueOf(object), empty);
     }
 
     public static void infoList(Object... args){
-        if(level.ordinal() > LogLevel.info.ordinal()) return;
+        if(isLevelMoreThan(LogLevel.info)) return;
         StringBuilder build = new StringBuilder();
-        for(Object o : args){
-            build.append(o);
-            build.append(" ");
+        for (int i = 0; i < args.length; i++){
+            build.append(args[i]);
+            if(i + 1 < args.length) build.append(" ");
         }
-        info(build.toString());
+        logger.log(LogLevel.info, "", build.toString(), empty);
     }
 
     public static void infoTag(String tag, String text){
-        log(LogLevel.info, "[" + tag + "] " + text);
+        if(isLevelMoreThan(LogLevel.info)) return;
+        logger.log(LogLevel.info, tag, text, empty);
     }
 
     public static void info(String text, Object... args){
-        log(LogLevel.info, text, args);
+        if(isLevelMoreThan(LogLevel.info)) return;
+        logger.log(LogLevel.info, "", text, args);
     }
 
     public static void info(Object object){
-        info(String.valueOf(object), empty);
+        if(isLevelMoreThan(LogLevel.info)) return;
+        logger.log(LogLevel.info, "", String.valueOf(object), empty);
     }
 
     public static void warn(String text, Object... args){
-        log(LogLevel.warn, text, args);
+        if(isLevelMoreThan(LogLevel.warn)) return;
+        logger.log(LogLevel.warn, "", text, args);
     }
 
     public static void errTag(String tag, String text){
-        log(LogLevel.err, "[" + tag + "] " + text);
+        if(isLevelMoreThan(LogLevel.err)) return;
+        logger.log(LogLevel.err, tag, text, empty);
     }
 
     public static void err(String text, Object... args){
-        log(LogLevel.err, text, args);
+        if(isLevelMoreThan(LogLevel.err)) return;
+        logger.log(LogLevel.err, "", text, args);
     }
 
     public static void err(Throwable th){
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        th.printStackTrace(pw);
-        err(sw.toString());
+        if(Log.level.ordinal() > LogLevel.err.ordinal()) return;
+        logger.log(LogLevel.err, "", "", th);
     }
 
     public static void err(String text, Throwable th){
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        th.printStackTrace(pw);
-        err(text + ": " + sw);
+        if(Log.level.ordinal() > LogLevel.err.ordinal()) return;
+        logger.log(LogLevel.err, "", text, th);
     }
 
     public static String format(String text, Object... args){
@@ -94,6 +100,10 @@ public class Log{
         return text;
     }
 
+    private static boolean isLevelMoreThan(LogLevel level){
+        return Log.level.ordinal() > level.ordinal();
+    }
+
     public enum LogLevel{
         debug,
         info,
@@ -116,6 +126,15 @@ public class Log{
 
     public interface LogHandler{
         void log(LogLevel level, String text);
+
+        default void log(LogLevel level, String tag, String text, Throwable th){
+            text = text + (text.isEmpty() ? "" : ": ") + Strings.getStackTrace(th);
+            this.log(level, (tag.isEmpty() ? "" : "[" + tag + "] ") + format(text, empty));
+        }
+
+        default void log(LogLevel level, String tag, String text, Object... args){
+            this.log(level, (tag.isEmpty() ? "" : "[" + tag + "] ") + format(text, args));
+        }
     }
 
     public static class DefaultLogHandler implements LogHandler{
@@ -132,6 +151,7 @@ public class Log{
 
     public static class NoopLogHandler implements LogHandler{
         @Override public void log(LogLevel level, String text){}
+        @Override public void log(LogLevel level, String tag, String text, Throwable th){}
+        @Override public void log(LogLevel level, String tag, String text, Object... args){}
     }
-
 }

--- a/arc-core/src/arc/util/Log.java
+++ b/arc-core/src/arc/util/Log.java
@@ -26,7 +26,7 @@ public class Log{
 
     public static void infoList(Object... args){
         StringBuilder build = new StringBuilder();
-        for (int i = 0; i < args.length; i++){
+        for(int i = 0; i < args.length; i++){
             build.append(args[i]);
             if(i + 1 < args.length) build.append(" ");
         }

--- a/arc-core/src/arc/util/Log.java
+++ b/arc-core/src/arc/util/Log.java
@@ -9,27 +9,22 @@ public class Log{
     public static LogFormatter formatter = new DefaultLogFormatter();
 
     public static void log(LogLevel level, String text, Object... args){
-        if(isLevelMoreThan(level)) return;
         logger.log(level, "", text, args);
     }
 
     public static void logTag(LogLevel level, String tag, String text, Object... args){
-        if(isLevelMoreThan(level)) return;
         logger.log(level, tag, text, args);
     }
 
     public static void debug(String text, Object... args){
-        if(isLevelMoreThan(LogLevel.debug)) return;
         logger.log(LogLevel.debug, "", text, args);
     }
     
     public static void debug(Object object){
-        if(isLevelMoreThan(LogLevel.debug)) return;
         logger.log(LogLevel.debug, "", String.valueOf(object), empty);
     }
 
     public static void infoList(Object... args){
-        if(isLevelMoreThan(LogLevel.info)) return;
         StringBuilder build = new StringBuilder();
         for (int i = 0; i < args.length; i++){
             build.append(args[i]);
@@ -39,42 +34,34 @@ public class Log{
     }
 
     public static void infoTag(String tag, String text){
-        if(isLevelMoreThan(LogLevel.info)) return;
         logger.log(LogLevel.info, tag, text, empty);
     }
 
     public static void info(String text, Object... args){
-        if(isLevelMoreThan(LogLevel.info)) return;
         logger.log(LogLevel.info, "", text, args);
     }
 
     public static void info(Object object){
-        if(isLevelMoreThan(LogLevel.info)) return;
         logger.log(LogLevel.info, "", String.valueOf(object), empty);
     }
 
     public static void warn(String text, Object... args){
-        if(isLevelMoreThan(LogLevel.warn)) return;
         logger.log(LogLevel.warn, "", text, args);
     }
 
     public static void errTag(String tag, String text){
-        if(isLevelMoreThan(LogLevel.err)) return;
         logger.log(LogLevel.err, tag, text, empty);
     }
 
     public static void err(String text, Object... args){
-        if(isLevelMoreThan(LogLevel.err)) return;
         logger.log(LogLevel.err, "", text, args);
     }
 
     public static void err(Throwable th){
-        if(Log.level.ordinal() > LogLevel.err.ordinal()) return;
         logger.log(LogLevel.err, "", "", th);
     }
 
     public static void err(String text, Throwable th){
-        if(Log.level.ordinal() > LogLevel.err.ordinal()) return;
         logger.log(LogLevel.err, "", text, th);
     }
 
@@ -98,10 +85,6 @@ public class Log{
             text = text.replace("&" + ColorCodes.codes[i], ColorCodes.values[i]);
         }
         return text;
-    }
-
-    private static boolean isLevelMoreThan(LogLevel level){
-        return Log.level.ordinal() > level.ordinal();
     }
 
     public enum LogLevel{
@@ -128,11 +111,13 @@ public class Log{
         void log(LogLevel level, String text);
 
         default void log(LogLevel level, String tag, String text, Throwable th){
+            if(Log.level.ordinal() > level.ordinal()) return;
             text = text + (text.isEmpty() ? "" : ": ") + Strings.getStackTrace(th);
             this.log(level, (tag.isEmpty() ? "" : "[" + tag + "] ") + format(text, empty));
         }
 
         default void log(LogLevel level, String tag, String text, Object... args){
+            if(Log.level.ordinal() > level.ordinal()) return;
             this.log(level, (tag.isEmpty() ? "" : "[" + tag + "] ") + format(text, args));
         }
     }

--- a/arc-core/src/arc/util/Log.java
+++ b/arc-core/src/arc/util/Log.java
@@ -9,19 +9,19 @@ public class Log{
     public static LogFormatter formatter = new DefaultLogFormatter();
 
     public static void log(LogLevel level, String text, Object... args){
-        logger.log(level, "", "", text, args);
+        logger.log(level, "", text, args);
     }
 
     public static void logTag(LogLevel level, String tag, String text, Object... args){
-        logger.log(level, tag, "", text, args);
+        logger.log(level, tag, text, args);
     }
 
     public static void debug(String text, Object... args){
-        logger.log(LogLevel.debug, "", "", text, args);
+        logger.log(LogLevel.debug, "", text, args);
     }
     
     public static void debug(Object object){
-        logger.log(LogLevel.debug, "", "", String.valueOf(object), empty);
+        logger.log(LogLevel.debug, "", String.valueOf(object), empty);
     }
 
     public static void infoList(Object... args){
@@ -30,39 +30,39 @@ public class Log{
             build.append(args[i]);
             if(i + 1 < args.length) build.append(" ");
         }
-        logger.log(LogLevel.info, "", "", build.toString(), empty);
+        logger.log(LogLevel.info, "", build.toString(), empty);
     }
 
     public static void infoTag(String tag, String text){
-        logger.log(LogLevel.info, tag, "", text, empty);
+        logger.log(LogLevel.info, tag, text, empty);
     }
 
     public static void info(String text, Object... args){
-        logger.log(LogLevel.info, "", "", text, args);
+        logger.log(LogLevel.info, "", text, args);
     }
 
     public static void info(Object object){
-        logger.log(LogLevel.info, "", "", String.valueOf(object), empty);
+        logger.log(LogLevel.info, "", String.valueOf(object), empty);
     }
 
     public static void warn(String text, Object... args){
-        logger.log(LogLevel.warn, "", "", text, args);
+        logger.log(LogLevel.warn, "", text, args);
     }
 
     public static void errTag(String tag, String text){
-        logger.log(LogLevel.err, tag, "", text, empty);
+        logger.log(LogLevel.err, tag, text, empty);
     }
 
     public static void err(String text, Object... args){
-        logger.log(LogLevel.err, "", "", text, args);
+        logger.log(LogLevel.err, "", text, args);
     }
 
     public static void err(Throwable th){
-        logger.log(LogLevel.err, "", "", "", th);
+        logger.log(LogLevel.err, "", "", th);
     }
 
     public static void err(String text, Throwable th){
-        logger.log(LogLevel.err, "", "", text, th);
+        logger.log(LogLevel.err, "", text, th);
     }
 
     public static String format(String text, Object... args){
@@ -85,10 +85,6 @@ public class Log{
             text = text.replace("&" + ColorCodes.codes[i], ColorCodes.values[i]);
         }
         return text;
-    }
-
-    private static String tagOrEmpty(final String value){
-        return value.isEmpty() ? "" : "[" + value + "] ";
     }
 
     public enum LogLevel{
@@ -114,15 +110,15 @@ public class Log{
     public interface LogHandler{
         void log(LogLevel level, String text);
 
-        default void log(LogLevel level, String tag, String topic, String text, Throwable th){
+        default void log(LogLevel level, String tag, String text, Throwable th){
             if(Log.level.ordinal() > level.ordinal()) return;
             text = text + (text.isEmpty() ? "" : ": ") + Strings.getStackTrace(th);
-            this.log(level, tagOrEmpty(tag) + tagOrEmpty(topic) + format(text, empty));
+            this.log(level, (tag.isEmpty() ? "" : "[" + tag + "] ") + format(text, empty));
         }
 
-        default void log(LogLevel level, String tag, String topic, String text, Object... args){
+        default void log(LogLevel level, String tag, String text, Object... args){
             if(Log.level.ordinal() > level.ordinal()) return;
-            this.log(level, tagOrEmpty(tag) + tagOrEmpty(topic) + format(text, args));
+            this.log(level, (tag.isEmpty() ? "" : "[" + tag + "] ") + format(text, args));
         }
     }
 
@@ -140,7 +136,7 @@ public class Log{
 
     public static class NoopLogHandler implements LogHandler{
         @Override public void log(LogLevel level, String text){}
-        @Override public void log(LogLevel level, String tag, String topic, String text, Throwable th){}
-        @Override public void log(LogLevel level, String tag, String topic, String text, Object... args){}
+        @Override public void log(LogLevel level, String tag, String text, Throwable th){}
+        @Override public void log(LogLevel level, String tag, String text, Object... args){}
     }
 }

--- a/arc-core/src/arc/util/Log.java
+++ b/arc-core/src/arc/util/Log.java
@@ -112,7 +112,7 @@ public class Log{
 
         default void log(LogLevel level, String tag, String text, Throwable th){
             if(Log.level.ordinal() > level.ordinal()) return;
-            text = text + (text.isEmpty() ? "" : ": ") + Strings.getStackTrace(th);
+            text += (text.isEmpty() ? "" : ": ") + Strings.getStackTrace(th);
             this.log(level, (tag.isEmpty() ? "" : "[" + tag + "] ") + format(text, empty));
         }
 

--- a/arc-core/src/arc/util/Log.java
+++ b/arc-core/src/arc/util/Log.java
@@ -9,19 +9,19 @@ public class Log{
     public static LogFormatter formatter = new DefaultLogFormatter();
 
     public static void log(LogLevel level, String text, Object... args){
-        logger.log(level, "", text, args);
+        logger.log(level, "", "", text, args);
     }
 
     public static void logTag(LogLevel level, String tag, String text, Object... args){
-        logger.log(level, tag, text, args);
+        logger.log(level, tag, "", text, args);
     }
 
     public static void debug(String text, Object... args){
-        logger.log(LogLevel.debug, "", text, args);
+        logger.log(LogLevel.debug, "", "", text, args);
     }
     
     public static void debug(Object object){
-        logger.log(LogLevel.debug, "", String.valueOf(object), empty);
+        logger.log(LogLevel.debug, "", "", String.valueOf(object), empty);
     }
 
     public static void infoList(Object... args){
@@ -30,39 +30,39 @@ public class Log{
             build.append(args[i]);
             if(i + 1 < args.length) build.append(" ");
         }
-        logger.log(LogLevel.info, "", build.toString(), empty);
+        logger.log(LogLevel.info, "", "", build.toString(), empty);
     }
 
     public static void infoTag(String tag, String text){
-        logger.log(LogLevel.info, tag, text, empty);
+        logger.log(LogLevel.info, tag, "", text, empty);
     }
 
     public static void info(String text, Object... args){
-        logger.log(LogLevel.info, "", text, args);
+        logger.log(LogLevel.info, "", "", text, args);
     }
 
     public static void info(Object object){
-        logger.log(LogLevel.info, "", String.valueOf(object), empty);
+        logger.log(LogLevel.info, "", "", String.valueOf(object), empty);
     }
 
     public static void warn(String text, Object... args){
-        logger.log(LogLevel.warn, "", text, args);
+        logger.log(LogLevel.warn, "", "", text, args);
     }
 
     public static void errTag(String tag, String text){
-        logger.log(LogLevel.err, tag, text, empty);
+        logger.log(LogLevel.err, tag, "", text, empty);
     }
 
     public static void err(String text, Object... args){
-        logger.log(LogLevel.err, "", text, args);
+        logger.log(LogLevel.err, "", "", text, args);
     }
 
     public static void err(Throwable th){
-        logger.log(LogLevel.err, "", "", th);
+        logger.log(LogLevel.err, "", "", "", th);
     }
 
     public static void err(String text, Throwable th){
-        logger.log(LogLevel.err, "", text, th);
+        logger.log(LogLevel.err, "", "", text, th);
     }
 
     public static String format(String text, Object... args){
@@ -85,6 +85,10 @@ public class Log{
             text = text.replace("&" + ColorCodes.codes[i], ColorCodes.values[i]);
         }
         return text;
+    }
+
+    private static String tagOrEmpty(final String value){
+        return value.isEmpty() ? "" : "[" + value + "] ";
     }
 
     public enum LogLevel{
@@ -110,15 +114,15 @@ public class Log{
     public interface LogHandler{
         void log(LogLevel level, String text);
 
-        default void log(LogLevel level, String tag, String text, Throwable th){
+        default void log(LogLevel level, String tag, String topic, String text, Throwable th){
             if(Log.level.ordinal() > level.ordinal()) return;
             text = text + (text.isEmpty() ? "" : ": ") + Strings.getStackTrace(th);
-            this.log(level, (tag.isEmpty() ? "" : "[" + tag + "] ") + format(text, empty));
+            this.log(level, tagOrEmpty(tag) + tagOrEmpty(topic) + format(text, empty));
         }
 
-        default void log(LogLevel level, String tag, String text, Object... args){
+        default void log(LogLevel level, String tag, String topic, String text, Object... args){
             if(Log.level.ordinal() > level.ordinal()) return;
-            this.log(level, (tag.isEmpty() ? "" : "[" + tag + "] ") + format(text, args));
+            this.log(level, tagOrEmpty(tag) + tagOrEmpty(topic) + format(text, args));
         }
     }
 
@@ -136,7 +140,7 @@ public class Log{
 
     public static class NoopLogHandler implements LogHandler{
         @Override public void log(LogLevel level, String text){}
-        @Override public void log(LogLevel level, String tag, String text, Throwable th){}
-        @Override public void log(LogLevel level, String tag, String text, Object... args){}
+        @Override public void log(LogLevel level, String tag, String topic, String text, Throwable th){}
+        @Override public void log(LogLevel level, String tag, String topic, String text, Object... args){}
     }
 }

--- a/arc-core/src/arc/util/Log.java
+++ b/arc-core/src/arc/util/Log.java
@@ -113,12 +113,12 @@ public class Log{
         default void log(LogLevel level, String tag, String text, Throwable th){
             if(Log.level.ordinal() > level.ordinal()) return;
             text += (text.isEmpty() ? "" : ": ") + Strings.getStackTrace(th);
-            this.log(level, (tag.isEmpty() ? "" : "[" + tag + "] ") + format(text, empty));
+            this.log(level, format((tag.isEmpty() ? "" : "[" + tag + "] ") + text, empty));
         }
 
         default void log(LogLevel level, String tag, String text, Object... args){
             if(Log.level.ordinal() > level.ordinal()) return;
-            this.log(level, (tag.isEmpty() ? "" : "[" + tag + "] ") + format(text, args));
+            this.log(level, format((tag.isEmpty() ? "" : "[" + tag + "] ") + text, args));
         }
     }
 

--- a/arc-core/src/arc/util/Log.java
+++ b/arc-core/src/arc/util/Log.java
@@ -25,12 +25,7 @@ public class Log{
     }
 
     public static void infoList(Object... args){
-        StringBuilder build = new StringBuilder();
-        for(int i = 0; i < args.length; i++){
-            build.append(args[i]);
-            if(i + 1 < args.length) build.append(" ");
-        }
-        logger.log(LogLevel.info, "", build.toString(), empty);
+        logger.logList(LogLevel.info, "", args);
     }
 
     public static void infoTag(String tag, String text){
@@ -58,11 +53,11 @@ public class Log{
     }
 
     public static void err(Throwable th){
-        logger.log(LogLevel.err, "", "", th);
+        logger.logException(LogLevel.err, "", "", th);
     }
 
     public static void err(String text, Throwable th){
-        logger.log(LogLevel.err, "", text, th);
+        logger.logException(LogLevel.err, "", text, th);
     }
 
     public static String format(String text, Object... args){
@@ -110,15 +105,26 @@ public class Log{
     public interface LogHandler{
         void log(LogLevel level, String text);
 
-        default void log(LogLevel level, String tag, String text, Throwable th){
-            if(Log.level.ordinal() > level.ordinal()) return;
-            text += (text.isEmpty() ? "" : ": ") + Strings.getStackTrace(th);
-            this.log(level, format((tag.isEmpty() ? "" : "[" + tag + "] ") + text, empty));
-        }
-
         default void log(LogLevel level, String tag, String text, Object... args){
             if(Log.level.ordinal() > level.ordinal()) return;
             this.log(level, format((tag.isEmpty() ? "" : "[" + tag + "] ") + text, args));
+        }
+
+        default void logList(LogLevel level, String tag, Object... args){
+            if(Log.level.ordinal() > level.ordinal()) return;
+            StringBuilder build = new StringBuilder();
+            build.append(tag.isEmpty() ? "" : "[" + tag + "] ");
+            for(int i = 0; i < args.length; i++){
+                build.append(args[i]);
+                if(i + 1 < args.length) build.append(" ");
+            }
+            this.log(level, format(build.toString(), args));
+        }
+
+        default void logException(LogLevel level, String tag, String text, Throwable th){
+            if(Log.level.ordinal() > level.ordinal()) return;
+            text += (text.isEmpty() ? "" : ": ") + Strings.getStackTrace(th);
+            this.log(level, format((tag.isEmpty() ? "" : "[" + tag + "] ") + text, empty));
         }
     }
 
@@ -136,7 +142,7 @@ public class Log{
 
     public static class NoopLogHandler implements LogHandler{
         @Override public void log(LogLevel level, String text){}
-        @Override public void log(LogLevel level, String tag, String text, Throwable th){}
+        @Override public void logException(LogLevel level, String tag, String text, Throwable th){}
         @Override public void log(LogLevel level, String tag, String text, Object... args){}
     }
 }

--- a/arc-core/src/arc/util/Log.java
+++ b/arc-core/src/arc/util/Log.java
@@ -142,7 +142,8 @@ public class Log{
 
     public static class NoopLogHandler implements LogHandler{
         @Override public void log(LogLevel level, String text){}
-        @Override public void logException(LogLevel level, String tag, String text, Throwable th){}
         @Override public void log(LogLevel level, String tag, String text, Object... args){}
+        @Override public void logList(LogLevel level, String tag, Object... args) {}
+        @Override public void logException(LogLevel level, String tag, String text, Throwable th){}
     }
 }

--- a/arc-core/src/arc/util/Log.java
+++ b/arc-core/src/arc/util/Log.java
@@ -143,7 +143,7 @@ public class Log{
     public static class NoopLogHandler implements LogHandler{
         @Override public void log(LogLevel level, String text){}
         @Override public void log(LogLevel level, String tag, String text, Object... args){}
-        @Override public void logList(LogLevel level, String tag, Object... args) {}
+        @Override public void logList(LogLevel level, String tag, Object... args){}
         @Override public void logException(LogLevel level, String tag, String text, Throwable th){}
     }
 }

--- a/arc-core/src/arc/util/Log.java
+++ b/arc-core/src/arc/util/Log.java
@@ -118,7 +118,7 @@ public class Log{
                 build.append(args[i]);
                 if(i + 1 < args.length) build.append(" ");
             }
-            this.log(level, format(build.toString(), args));
+            this.log(level, format(build.toString(), empty));
         }
 
         default void logException(LogLevel level, String tag, String text, Throwable th){


### PR DESCRIPTION
The current `LogHandler` interface only receives the level and the formatted text of log events.

There is no way to know which mod/plugin emitted it, nor the original text, args and/or exception.

This PR solves this by adding log methods to the `LogHandler` that can receive that information.

Very useful for:
- Rate limiting some log events (since you have the original text and not the formatted one that can change due to args).
- Having the actual exception for alerts.
- Per mod/plugin log levels (silencing plugin A, lowering the log level of plugin B, etc.)