### PR TITLE
Add native Linux ARM64 build configuration

### DIFF
--- a/backends/backend-sdl/build.gradle
+++ b/backends/backend-sdl/build.gradle
@@ -92,11 +92,22 @@ jnigen{
         headerDirs = ["$mainRoot/glew-2.2.0/include"]
     }
 
-    addLinux(x64, x86){
-        cppFlags += execCmd("sdl2-config --cflags").split(" ")
-        cFlags = cppFlags
-        libraries = (execCmd("sdl2-config --libs") + " -Wl,-Bdynamic -lGL").split(" ")
-        linkerFlags = "-shared -m64".split(" ")
+    def isArm64 = System.getProperty("os.arch") == "aarch64" || System.getProperty("os.arch") == "arm64"
+
+    if(!isArm64){
+        addLinux(x64, x86){
+            cppFlags += execCmd("sdl2-config --cflags").split(" ")
+            cFlags = cppFlags
+            libraries = (execCmd("sdl2-config --libs") + " -Wl,-Bdynamic -lGL").split(" ")
+            linkerFlags = "-shared -m64".split(" ")
+        }
+    }else{
+        addLinux(x64, ARM){
+            cFlags = (execCmd("sdl2-config --cflags") + " -c -Wall -O2 -fPIC -fmessage-length=0").split(" ")
+            cppFlags = cFlags
+            libraries = (execCmd("sdl2-config --libs") + " -Wl,-Bdynamic -lGL").split(" ")
+            linkerFlags = "-shared".split(" ")
+        }
     }
 
     addWindows(x64, x86){


### PR DESCRIPTION
### Summary
This PR adds support for building native `Linux ARM64` JNI libraries (`libsdl-arcarm64.so`) in `backend-sdl`.

### Problem
Currently, `backend-sdl` lacks Linux ARM64 configuration. Running Mindustry natively on Linux ARM64 devices (e.g. Raspberry Pi 5, Rockchip RK3588, Snapdragon Linux laptops/handhelds) fails with:
`Couldn't load shared library 'libsdl-arcarm64.so' for target: Linux, 64-bit`.

### Changes
1. Added `"libs/linuxarm64"` to `sourceSets.main.resources.srcDirs` so that ARM64 natives are included in desktop JAR packaging.
2. Configured `addLinux(x64, ARM)` under `jnigen` with appropriate compiler/linker flags (`-c`, `-fPIC`, SDL2/GL flags) when running on `aarch64` hosts.

### Verification
- Tested building with `./gradlew :backends:backend-sdl:jnigenBuildAllLinux` on an AArch64 Linux environment.
- Generated `libsdl-arcarm64.so` successfully and verified game launches natively without Box64.

### Notes
Added Linux ARM64 build configuration and resource paths. Verified building and running successfully on native ARM64 devices. If desired, CI cross-compilation in natives.yml can be added as a follow-up.