### PR TITLE
Fixes #12640: Unset keybinding not saved

### DIFF
--- a/arc-core/src/arc/input/KeyBind.java
+++ b/arc-core/src/arc/input/KeyBind.java
@@ -69,8 +69,8 @@ public class KeyBind{
         Axis loaded;
         String name = settingsKey();
         if(settings.getBool(name + "-single", true)){
-            KeyCode key = KeyCode.byOrdinal(settings.getInt(name + "-key", KeyCode.unset.ordinal()));
-            loaded = key == KeyCode.unset ? null : new Axis(key);
+            int ordinal = settings.getInt(name + "-key", -1);
+            loaded = ordinal < 0 ? null : new Axis(KeyCode.byOrdinal(ordinal));
         }else{
             KeyCode min = KeyCode.byOrdinal(settings.getInt(name + "-min", KeyCode.unset.ordinal()));
             KeyCode max = KeyCode.byOrdinal(settings.getInt(name + "-max", KeyCode.unset.ordinal()));
@@ -101,11 +101,6 @@ public class KeyBind{
     }
 
     public void unset(){
-        String name = settingsKey();
-        settings.remove(name + "-single");
-        settings.remove(name + "-key");
-        settings.remove(name + "-min");
-        settings.remove(name + "-max");
         value = new Axis(KeyCode.unset);
     }
 


### PR DESCRIPTION
Fixes https://github.com/Anuken/Mindustry/issues/12640.

Needs a change in arc, because the `unset` keybind was used to detect a non-existent keybind in settings.